### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run typecheck
+      - run: bun test


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs on pushes and PRs to `main`
- Installs Bun, runs `bun run typecheck` and `bun test`

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm typecheck and tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)