### PR TITLE
Add Biome linting and replace typecheck with lint command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install
-      - run: bun run typecheck
+      - run: bun run lint
       - run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@ apple-notes-ts — TypeScript package for reading and searching Apple Notes on m
 ## Commands
 
 - `bun test` — Run all tests (74 tests against fixture DB, no Full Disk Access needed)
-- `bun run typecheck` — TypeScript type checking
+- `bun run lint` — TypeScript type checking + Biome linting/format checking
+- `bun run format` — Auto-fix lint issues and reformat with Biome
 - `bun example` — List notes on this machine and display one at random (requires Full Disk Access)
 - `bun run create-fixture` — Regenerate the test fixture database
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "linter": {
+    "enabled": true
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "files": {
+    "includes": ["**", "!**/tests/fixtures"]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "protobufjs": "^8.0.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.11",
         "@types/bun": "latest",
       },
       "peerDependencies": {
@@ -16,6 +17,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.11", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.11", "@biomejs/cli-darwin-x64": "2.4.11", "@biomejs/cli-linux-arm64": "2.4.11", "@biomejs/cli-linux-arm64-musl": "2.4.11", "@biomejs/cli-linux-x64": "2.4.11", "@biomejs/cli-linux-x64-musl": "2.4.11", "@biomejs/cli-win32-arm64": "2.4.11", "@biomejs/cli-win32-x64": "2.4.11" }, "bin": { "biome": "bin/biome" } }, "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.11", "", { "os": "linux", "cpu": "x64" }, "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],

--- a/example.ts
+++ b/example.ts
@@ -42,7 +42,8 @@ const readable = allNotes.filter((n) => !n.isPasswordProtected);
 if (readable.length === 0) {
   console.log("No readable notes found.");
 } else {
-  const pick = readable[Math.floor(Math.random() * readable.length)]!;
+  const pick = readable[Math.floor(Math.random() * readable.length)];
+  if (!pick) throw new Error("unreachable");
   console.log(`--- Random note: "${pick.title}" ---`);
   console.log();
 
@@ -55,7 +56,9 @@ if (readable.length === 0) {
     console.log();
     console.log(`Attachments (${attachments.length}):`);
     for (const a of attachments) {
-      console.log(`  - ${a.name} (${a.contentType}) → ${a.url ?? "unresolved"}`);
+      console.log(
+        `  - ${a.name} (${a.contentType}) → ${a.url ?? "unresolved"}`,
+      );
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "private": true,
   "scripts": {
     "test": "bun test",
-    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit && biome check .",
+    "format": "biome check --write .",
     "example": "bun run example.ts",
     "create-fixture": "bun run tests/fixtures/create-test-db.ts"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.11",
     "@types/bun": "latest"
   },
   "peerDependencies": {

--- a/src/apple-notes.ts
+++ b/src/apple-notes.ts
@@ -1,23 +1,20 @@
 import type { Database } from "bun:sqlite";
+import { AttachmentResolver } from "./attachments/resolver.ts";
+import { noteToMarkdown } from "./conversion/proto-to-markdown.ts";
 import { openDatabase } from "./database/connection.ts";
 import { NoteReader } from "./database/reader.ts";
+import { NoteNotFoundError, PasswordProtectedError } from "./errors.ts";
 import { decodeNoteData } from "./protobuf/decode.ts";
-import { noteToMarkdown } from "./conversion/proto-to-markdown.ts";
-import { AttachmentResolver } from "./attachments/resolver.ts";
-import {
-  NoteNotFoundError,
-  PasswordProtectedError,
-} from "./errors.ts";
 import type {
   Account,
+  AttachmentRef,
   Folder,
-  NoteMeta,
+  ListNotesOptions,
   NoteContent,
   NoteContentPage,
-  AttachmentRef,
-  SearchOptions,
-  ListNotesOptions,
+  NoteMeta,
   PaginationOptions,
+  SearchOptions,
 } from "./types.ts";
 
 export interface AppleNotesOptions {

--- a/src/attachments/resolver.ts
+++ b/src/attachments/resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
 import { homedir } from "node:os";
+import { join } from "node:path";
 
 const DEFAULT_CONTAINER_PATH = join(
   homedir(),
@@ -45,7 +45,10 @@ export class AttachmentResolver {
           // Recurse one level only to avoid excessive scanning
           const subEntries = readdirSync(fullPath, { withFileTypes: true });
           for (const sub of subEntries) {
-            if (sub.isDirectory() && (sub.name === identifier || sub.name.includes(identifier))) {
+            if (
+              sub.isDirectory() &&
+              (sub.name === identifier || sub.name.includes(identifier))
+            ) {
               const subPath = join(fullPath, sub.name);
               const files = readdirSync(subPath, { withFileTypes: true });
               const file = files.find((f) => f.isFile());

--- a/src/conversion/proto-to-markdown.ts
+++ b/src/conversion/proto-to-markdown.ts
@@ -1,12 +1,12 @@
-import type { DecodedNote, DecodedAttributeRun } from "../protobuf/decode.ts";
+import type { DecodedAttributeRun, DecodedNote } from "../protobuf/decode.ts";
 
 // ParagraphStyle.style_type values (from notestore.proto)
 const STYLE_TITLE = 0;
 const STYLE_HEADING = 1;
 const STYLE_SUBHEADING = 2;
 const STYLE_MONOSPACED = 4;
-const STYLE_DOTTED_LIST = 100;  // bullet (dotted)
-const STYLE_DASHED_LIST = 101;  // bullet (dashed)
+const STYLE_DOTTED_LIST = 100; // bullet (dotted)
+const STYLE_DASHED_LIST = 101; // bullet (dashed)
 const STYLE_NUMBERED_LIST = 102;
 const STYLE_CHECKLIST = 103;
 
@@ -201,7 +201,8 @@ function renderInlineFormatting(
       // font_weight: 1=bold, 2=italic, 3=bold+italic
       const fw = run.fontWeight ?? 0;
       const isBold = fw === FONT_WEIGHT_BOLD || fw === FONT_WEIGHT_BOLD_ITALIC;
-      const isItalic = fw === FONT_WEIGHT_ITALIC || fw === FONT_WEIGHT_BOLD_ITALIC;
+      const isItalic =
+        fw === FONT_WEIGHT_ITALIC || fw === FONT_WEIGHT_BOLD_ITALIC;
 
       if (isBold && isItalic) {
         formatted = `***${formatted}***`;

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { existsSync } from "node:fs";
 import { DatabaseNotFoundError } from "../errors.ts";
 
 const DEFAULT_DB_PATH = join(
@@ -18,7 +18,7 @@ export function openDatabase(dbPath?: string): Database {
 
   try {
     return new Database(path, { readonly: true });
-  } catch (error) {
+  } catch (_error) {
     throw new DatabaseNotFoundError(path);
   }
 }

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -1,11 +1,11 @@
 import type { Database } from "bun:sqlite";
 import type {
   Account,
-  Folder,
-  NoteMeta,
   AttachmentRef,
-  SearchOptions,
+  Folder,
   ListNotesOptions,
+  NoteMeta,
+  SearchOptions,
 } from "../types.ts";
 import * as Q from "./queries.ts";
 
@@ -166,7 +166,9 @@ export class NoteReader {
     return results;
   }
 
-  listNotes(options?: ListNotesOptions): { meta: NoteMeta; zdata: Buffer | null }[] {
+  listNotes(
+    options?: ListNotesOptions,
+  ): { meta: NoteMeta; zdata: Buffer | null }[] {
     const rows = this.db
       .query(Q.LIST_NOTES)
       .all(this.entityTypes.note) as NoteRow[];
@@ -179,7 +181,7 @@ export class NoteReader {
     if (options?.folder) {
       results = results.filter(
         (r) =>
-          r.meta.folderName.toLowerCase() === options.folder!.toLowerCase() ||
+          r.meta.folderName.toLowerCase() === options.folder?.toLowerCase() ||
           r.meta.folderId === Number(options.folder),
       );
     }
@@ -187,7 +189,7 @@ export class NoteReader {
     if (options?.account) {
       results = results.filter(
         (r) =>
-          r.meta.accountName.toLowerCase() === options.account!.toLowerCase() ||
+          r.meta.accountName.toLowerCase() === options.account?.toLowerCase() ||
           r.meta.accountId === Number(options.account),
       );
     }
@@ -204,10 +206,7 @@ export class NoteReader {
     };
   }
 
-  search(
-    query: string,
-    options?: SearchOptions,
-  ): NoteMeta[] {
+  search(query: string, options?: SearchOptions): NoteMeta[] {
     const pattern = `%${query}%`;
     const limit = options?.limit ?? 50;
 
@@ -220,7 +219,7 @@ export class NoteReader {
     if (options?.folder) {
       results = results.filter(
         (r) =>
-          r.folderName.toLowerCase() === options.folder!.toLowerCase() ||
+          r.folderName.toLowerCase() === options.folder?.toLowerCase() ||
           r.folderId === Number(options.folder),
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,23 @@
-export { AppleNotes } from "./apple-notes.ts";
 export type { AppleNotesOptions } from "./apple-notes.ts";
-export type {
-  NoteId,
-  FolderId,
-  AccountId,
-  AttachmentId,
-  Account,
-  Folder,
-  NoteMeta,
-  NoteContent,
-  NoteContentPage,
-  AttachmentRef,
-  SearchOptions,
-  ListNotesOptions,
-  PaginationOptions,
-} from "./types.ts";
+export { AppleNotes } from "./apple-notes.ts";
 export {
   AppleNotesError,
+  DatabaseNotFoundError,
   NoteNotFoundError,
   PasswordProtectedError,
-  DatabaseNotFoundError,
 } from "./errors.ts";
+export type {
+  Account,
+  AccountId,
+  AttachmentId,
+  AttachmentRef,
+  Folder,
+  FolderId,
+  ListNotesOptions,
+  NoteContent,
+  NoteContentPage,
+  NoteId,
+  NoteMeta,
+  PaginationOptions,
+  SearchOptions,
+} from "./types.ts";

--- a/src/protobuf/decode.ts
+++ b/src/protobuf/decode.ts
@@ -1,6 +1,6 @@
+import { resolve } from "node:path";
 import { gunzipSync } from "node:zlib";
 import protobuf from "protobufjs";
-import { resolve } from "node:path";
 
 export interface DecodedNote {
   text: string;
@@ -90,11 +90,14 @@ function toDecodedRun(raw: Record<string, unknown>): DecodedAttributeRun {
 
   if (raw.fontWeight != null) run.fontWeight = raw.fontWeight as number;
   if (raw.underlined != null) run.underlined = raw.underlined as number;
-  if (raw.strikethrough != null) run.strikethrough = raw.strikethrough as number;
+  if (raw.strikethrough != null)
+    run.strikethrough = raw.strikethrough as number;
   if (raw.superscript != null) run.superscript = raw.superscript as number;
   if (raw.link != null) run.link = raw.link as string;
-  if (raw.unknownIdentifier != null) run.unknownIdentifier = raw.unknownIdentifier as number;
-  if (raw.emphasisStyle != null) run.emphasisStyle = raw.emphasisStyle as number;
+  if (raw.unknownIdentifier != null)
+    run.unknownIdentifier = raw.unknownIdentifier as number;
+  if (raw.emphasisStyle != null)
+    run.emphasisStyle = raw.emphasisStyle as number;
 
   const color = raw.color as Record<string, unknown> | undefined;
   if (color) {

--- a/tests/apple-notes.test.ts
+++ b/tests/apple-notes.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
-import { AppleNotes } from "../src/index.ts";
 import { NoteNotFoundError, PasswordProtectedError } from "../src/errors.ts";
+import { AppleNotes } from "../src/index.ts";
 
 const FIXTURE_DB = resolve(import.meta.dir, "fixtures/NoteStore.sqlite");
 const FIXTURE_DIR = resolve(import.meta.dir, "fixtures");
@@ -54,13 +54,13 @@ describe("folders", () => {
     const folders = db.folders();
     const workFolder = folders.find((f) => f.name === "Work");
     expect(workFolder).toBeDefined();
-    expect(workFolder!.accountName).toBe("iCloud");
+    expect(workFolder?.accountName).toBe("iCloud");
   });
 
   test("filters by account name", () => {
     const folders = db.folders("On My Mac");
     expect(folders).toHaveLength(1);
-    expect(folders[0]!.name).toBe("Personal");
+    expect(folders[0]?.name).toBe("Personal");
   });
 });
 
@@ -86,17 +86,17 @@ describe("notes", () => {
     const notes = db.notes();
     const simple = notes.find((n) => n.title === "Simple Note");
     expect(simple).toBeDefined();
-    expect(simple!.snippet).toBeTruthy();
-    expect(simple!.createdAt).toBeInstanceOf(Date);
-    expect(simple!.modifiedAt).toBeInstanceOf(Date);
-    expect(simple!.isPasswordProtected).toBe(false);
+    expect(simple?.snippet).toBeTruthy();
+    expect(simple?.createdAt).toBeInstanceOf(Date);
+    expect(simple?.modifiedAt).toBeInstanceOf(Date);
+    expect(simple?.isPasswordProtected).toBe(false);
   });
 
   test("password protected note has flag set", () => {
     const notes = db.notes();
     const secret = notes.find((n) => n.title === "Secret Note");
     expect(secret).toBeDefined();
-    expect(secret!.isPasswordProtected).toBe(true);
+    expect(secret?.isPasswordProtected).toBe(true);
   });
 });
 
@@ -209,7 +209,9 @@ describe("read", () => {
 
   test("reads attachment placeholders", () => {
     const content = db.read(110);
-    expect(content.markdown).toContain("![attachment](attachment:ATTACH-UUID-001");
+    expect(content.markdown).toContain(
+      "![attachment](attachment:ATTACH-UUID-001",
+    );
   });
 
   test("throws NoteNotFoundError for missing note", () => {
@@ -281,7 +283,7 @@ describe("getAttachments", () => {
     // Note 110 has an attachment
     const attachments = db.getAttachments(110);
     expect(attachments.length).toBeGreaterThan(0);
-    expect(attachments[0]!.contentType).toBe("public.jpeg");
+    expect(attachments[0]?.contentType).toBe("public.jpeg");
   });
 
   test("returns empty array for note without attachments", () => {

--- a/tests/conversion.test.ts
+++ b/tests/conversion.test.ts
@@ -1,6 +1,9 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { noteToMarkdown } from "../src/conversion/proto-to-markdown.ts";
-import type { DecodedNote, DecodedAttributeRun } from "../src/protobuf/decode.ts";
+import type {
+  DecodedAttributeRun,
+  DecodedNote,
+} from "../src/protobuf/decode.ts";
 
 function note(text: string, runs: DecodedAttributeRun[]): DecodedNote {
   return { text, attributeRuns: runs };
@@ -12,9 +15,7 @@ describe("noteToMarkdown", () => {
   });
 
   test("renders plain text", () => {
-    const md = noteToMarkdown(
-      note("Hello world\n", [{ length: 12 }]),
-    );
+    const md = noteToMarkdown(note("Hello world\n", [{ length: 12 }]));
     expect(md).toBe("Hello world");
   });
 

--- a/tests/fixtures/create-test-db.ts
+++ b/tests/fixtures/create-test-db.ts
@@ -6,9 +6,9 @@
  */
 
 import { Database } from "bun:sqlite";
-import { gzipSync } from "node:zlib";
-import { resolve, dirname } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
 import protobuf from "protobufjs";
 
 const FIXTURE_DIR = dirname(new URL(import.meta.url).pathname);
@@ -195,9 +195,15 @@ function attachmentRun(
 try {
   Bun.file(DB_PATH).delete;
   const { unlinkSync } = await import("node:fs");
-  try { unlinkSync(DB_PATH); } catch {}
-  try { unlinkSync(DB_PATH + "-wal"); } catch {}
-  try { unlinkSync(DB_PATH + "-shm"); } catch {}
+  try {
+    unlinkSync(DB_PATH);
+  } catch {}
+  try {
+    unlinkSync(`${DB_PATH}-wal`);
+  } catch {}
+  try {
+    unlinkSync(`${DB_PATH}-shm`);
+  } catch {}
 } catch {}
 
 const db = new Database(DB_PATH);
@@ -373,12 +379,9 @@ insertNote({
   folderId: 10,
   createdAt: lastMonth,
   modifiedAt: lastWeek,
-  noteText: "Simple Note\nThis is a simple plain text note.\nIt has multiple lines.\n",
-  attributeRuns: [
-    titleRun(12),
-    bodyRun(34),
-    bodyRun(23),
-  ],
+  noteText:
+    "Simple Note\nThis is a simple plain text note.\nIt has multiple lines.\n",
+  attributeRuns: [titleRun(12), bodyRun(34), bodyRun(23)],
 });
 
 // Note 2: Rich formatting
@@ -391,7 +394,8 @@ insertNote({
   folderId: 10,
   createdAt: lastWeek,
   modifiedAt: yesterday,
-  noteText: "Formatted Note\nThis has bold and italic and bold italic text.\nAlso strikethrough and underline.\n",
+  noteText:
+    "Formatted Note\nThis has bold and italic and bold italic text.\nAlso strikethrough and underline.\n",
   attributeRuns: [
     titleRun(15),
     bodyRun(9),
@@ -418,10 +422,10 @@ insertNote({
   modifiedAt: now,
   noteText: "Headings Test\nMain Section\nSub Section\nBody text here.\n",
   attributeRuns: [
-    titleRun(14),       // "Headings Test\n"
-    headingRun(13),     // "Main Section\n"
-    subheadingRun(12),  // "Sub Section\n"
-    bodyRun(16),        // "Body text here.\n"
+    titleRun(14), // "Headings Test\n"
+    headingRun(13), // "Main Section\n"
+    subheadingRun(12), // "Sub Section\n"
+    bodyRun(16), // "Body text here.\n"
   ],
 });
 
@@ -432,14 +436,15 @@ insertNote({
   folderId: 11,
   createdAt: yesterday,
   modifiedAt: now,
-  noteText: "Lists Note\nFirst bullet\nSecond bullet\nNested bullet\nFirst numbered\nSecond numbered\n",
+  noteText:
+    "Lists Note\nFirst bullet\nSecond bullet\nNested bullet\nFirst numbered\nSecond numbered\n",
   attributeRuns: [
-    titleRun(11),           // "Lists Note\n"
-    bulletRun(13),          // "First bullet\n"
-    bulletRun(14),          // "Second bullet\n"
-    bulletRun(14, 1),       // "Nested bullet\n" (indent=1)
-    numberedRun(15),        // "First numbered\n"
-    numberedRun(16),        // "Second numbered\n"
+    titleRun(11), // "Lists Note\n"
+    bulletRun(13), // "First bullet\n"
+    bulletRun(14), // "Second bullet\n"
+    bulletRun(14, 1), // "Nested bullet\n" (indent=1)
+    numberedRun(15), // "First numbered\n"
+    numberedRun(16), // "Second numbered\n"
   ],
 });
 
@@ -452,11 +457,11 @@ insertNote({
   modifiedAt: now,
   noteText: "Todo List\nBuy groceries\nClean house\nWrite code\nReview PR\n",
   attributeRuns: [
-    titleRun(10),               // "Todo List\n"
-    checklistRun(14, true),     // "Buy groceries\n" (done)
-    checklistRun(12, false),    // "Clean house\n" (not done)
-    checklistRun(11, true),     // "Write code\n" (done)
-    checklistRun(10, false),    // "Review PR\n" (not done)
+    titleRun(10), // "Todo List\n"
+    checklistRun(14, true), // "Buy groceries\n" (done)
+    checklistRun(12, false), // "Clean house\n" (not done)
+    checklistRun(11, true), // "Write code\n" (done)
+    checklistRun(10, false), // "Review PR\n" (not done)
   ],
 });
 
@@ -468,7 +473,8 @@ insertNote({
   folderId: 10,
   createdAt: lastWeek,
   modifiedAt: yesterday,
-  noteText: "Code Example\nHere is some code:\nfunction hello() {\n  return 'world';\n}\nAnd that's it.\n",
+  noteText:
+    "Code Example\nHere is some code:\nfunction hello() {\n  return 'world';\n}\nAnd that's it.\n",
   attributeRuns: [
     titleRun(13),
     bodyRun(19),
@@ -486,15 +492,16 @@ insertNote({
   folderId: 12,
   createdAt: lastMonth,
   modifiedAt: lastWeek,
-  noteText: "Links Note\nVisit Example for more info.\nAlso check Other Site.\n",
+  noteText:
+    "Links Note\nVisit Example for more info.\nAlso check Other Site.\n",
   attributeRuns: [
-    titleRun(11),                                    // "Links Note\n"
-    bodyRun(6),                                      // "Visit "
-    linkRun(7, "https://example.com"),               // "Example"
-    bodyRun(16),                                     // " for more info.\n"
-    bodyRun(11),                                     // "Also check "
-    linkRun(10, "https://other-site.com"),            // "Other Site"
-    bodyRun(2),                                      // ".\n"
+    titleRun(11), // "Links Note\n"
+    bodyRun(6), // "Visit "
+    linkRun(7, "https://example.com"), // "Example"
+    bodyRun(16), // " for more info.\n"
+    bodyRun(11), // "Also check "
+    linkRun(10, "https://other-site.com"), // "Other Site"
+    bodyRun(2), // ".\n"
   ],
 });
 
@@ -506,13 +513,9 @@ insertNote({
   folderId: 12,
   createdAt: lastWeek,
   modifiedAt: yesterday,
-  noteText: "Quotes Note\nSomeone once said:\nTo be or not to be.\nThat is the question.\n",
-  attributeRuns: [
-    titleRun(12),
-    bodyRun(19),
-    blockQuoteRun(20),
-    bodyRun(22),
-  ],
+  noteText:
+    "Quotes Note\nSomeone once said:\nTo be or not to be.\nThat is the question.\n",
+  attributeRuns: [titleRun(12), bodyRun(19), blockQuoteRun(20), bodyRun(22)],
 });
 
 // Note 9: Large note (for pagination tests)
@@ -523,7 +526,7 @@ for (let i = 1; i <= 500; i++) {
   largeLines.push(line);
   largeRuns.push(bodyRun(line.length + 1)); // +1 for \n
 }
-const largeText = largeLines.join("\n") + "\n";
+const largeText = `${largeLines.join("\n")}\n`;
 
 insertNote({
   title: "Large Note",
@@ -558,10 +561,10 @@ insertNote({
   modifiedAt: now,
   noteText: "Note With Image\nHere is an image:\n\uFFFCAnd some text after.\n",
   attributeRuns: [
-    titleRun(16),                                       // "Note With Image\n"
-    bodyRun(18),                                        // "Here is an image:\n"
-    attachmentRun(attachmentId, "public.jpeg"),          // U+FFFC
-    bodyRun(21),                                        // "And some text after.\n"
+    titleRun(16), // "Note With Image\n"
+    bodyRun(18), // "Here is an image:\n"
+    attachmentRun(attachmentId, "public.jpeg"), // U+FFFC
+    bodyRun(21), // "And some text after.\n"
   ],
 });
 
@@ -581,12 +584,7 @@ insertNote({
   createdAt: now,
   modifiedAt: now,
   noteText: "Inline Code Note\nUse the console.log function in your code.\n",
-  attributeRuns: [
-    titleRun(17),
-    bodyRun(8),
-    inlineCodeRun(11),
-    bodyRun(24),
-  ],
+  attributeRuns: [titleRun(17), bodyRun(8), inlineCodeRun(11), bodyRun(24)],
 });
 
 // ============================================================================
@@ -595,10 +593,7 @@ insertNote({
 
 const attachDir = resolve(FIXTURE_DIR, "Accounts", attachmentId);
 mkdirSync(attachDir, { recursive: true });
-writeFileSync(
-  resolve(attachDir, "photo.jpg"),
-  "fake-jpeg-data-for-testing",
-);
+writeFileSync(resolve(attachDir, "photo.jpg"), "fake-jpeg-data-for-testing");
 
 // ============================================================================
 // Done

--- a/tests/protobuf.test.ts
+++ b/tests/protobuf.test.ts
@@ -1,7 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 import protobuf from "protobufjs";
-import { resolve } from "node:path";
 import { decodeNoteData } from "../src/protobuf/decode.ts";
 
 const PROTO_PATH = resolve(import.meta.dir, "../src/protobuf/notestore.proto");
@@ -28,7 +28,7 @@ describe("decodeNoteData", () => {
 
     expect(result.text).toBe("Hello world\n");
     expect(result.attributeRuns).toHaveLength(1);
-    expect(result.attributeRuns[0]!.length).toBe(12);
+    expect(result.attributeRuns[0]?.length).toBe(12);
   });
 
   test("decodes empty note", () => {
@@ -48,7 +48,7 @@ describe("decodeNoteData", () => {
     const result = decodeNoteData(zdata);
 
     expect(result.attributeRuns).toHaveLength(3);
-    expect(result.attributeRuns[1]!.fontWeight).toBe(1);
+    expect(result.attributeRuns[1]?.fontWeight).toBe(1);
   });
 
   test("decodes note with italic formatting", () => {
@@ -59,7 +59,7 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[1]!.fontWeight).toBe(2);
+    expect(result.attributeRuns[1]?.fontWeight).toBe(2);
   });
 
   test("decodes note with bold+italic formatting", () => {
@@ -70,7 +70,7 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[1]!.fontWeight).toBe(3);
+    expect(result.attributeRuns[1]?.fontWeight).toBe(3);
   });
 
   test("decodes paragraph styles", () => {
@@ -81,9 +81,9 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.paragraphStyle?.styleType).toBe(0);
-    expect(result.attributeRuns[1]!.paragraphStyle?.styleType).toBe(1);
-    expect(result.attributeRuns[2]!.paragraphStyle).toBeUndefined();
+    expect(result.attributeRuns[0]?.paragraphStyle?.styleType).toBe(0);
+    expect(result.attributeRuns[1]?.paragraphStyle?.styleType).toBe(1);
+    expect(result.attributeRuns[2]?.paragraphStyle).toBeUndefined();
   });
 
   test("decodes checklist items", () => {
@@ -106,8 +106,8 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.paragraphStyle?.checklist?.done).toBe(1);
-    expect(result.attributeRuns[1]!.paragraphStyle?.checklist?.done).toBe(0);
+    expect(result.attributeRuns[0]?.paragraphStyle?.checklist?.done).toBe(1);
+    expect(result.attributeRuns[1]?.paragraphStyle?.checklist?.done).toBe(0);
   });
 
   test("decodes strikethrough and underline", () => {
@@ -117,8 +117,8 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.strikethrough).toBe(1);
-    expect(result.attributeRuns[1]!.underlined).toBe(1);
+    expect(result.attributeRuns[0]?.strikethrough).toBe(1);
+    expect(result.attributeRuns[1]?.underlined).toBe(1);
   });
 
   test("decodes links", () => {
@@ -128,7 +128,7 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.link).toBe("https://example.com");
+    expect(result.attributeRuns[0]?.link).toBe("https://example.com");
   });
 
   test("decodes attachment info", () => {
@@ -144,10 +144,10 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.attachmentInfo?.attachmentIdentifier).toBe(
+    expect(result.attributeRuns[0]?.attachmentInfo?.attachmentIdentifier).toBe(
       "UUID-123",
     );
-    expect(result.attributeRuns[0]!.attachmentInfo?.typeUti).toBe(
+    expect(result.attributeRuns[0]?.attachmentInfo?.typeUti).toBe(
       "public.jpeg",
     );
   });
@@ -159,7 +159,7 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.font?.fontHints).toBe(1);
+    expect(result.attributeRuns[0]?.font?.fontHints).toBe(1);
   });
 
   test("decodes block quote", () => {
@@ -168,7 +168,7 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.paragraphStyle?.blockQuote).toBe(1);
+    expect(result.attributeRuns[0]?.paragraphStyle?.blockQuote).toBe(1);
   });
 
   test("decodes indent amount", () => {
@@ -180,14 +180,12 @@ describe("decodeNoteData", () => {
     ]);
     const result = decodeNoteData(zdata);
 
-    expect(result.attributeRuns[0]!.paragraphStyle?.indentAmount).toBe(2);
+    expect(result.attributeRuns[0]?.paragraphStyle?.indentAmount).toBe(2);
   });
 
   test("handles missing document gracefully", () => {
     const msg = NoteStoreProto.create({});
-    const zdata = Buffer.from(
-      gzipSync(NoteStoreProto.encode(msg).finish()),
-    );
+    const zdata = Buffer.from(gzipSync(NoteStoreProto.encode(msg).finish()));
     const result = decodeNoteData(zdata);
 
     expect(result.text).toBe("");


### PR DESCRIPTION
## Summary
- Installs `@biomejs/biome` and adds a `biome.json` config (2-space indent, recommended rules, tests/fixtures excluded)
- Replaces the `typecheck` script with `lint` (`tsc --noEmit && biome check .`) and adds a `format` script (`biome check --write .`)
- Updates CI workflow to run `bun run lint` instead of `bun run typecheck`
- Auto-fixes all existing lint issues across source and test files (non-null assertions → optional chains, unused variable rename, formatting normalization)

## Test plan
- [x] `bun run lint` passes clean
- [x] `bun test` — all 74 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)