### PR TITLE
Fix misleading error when Full Disk Access is missing

### DIFF
--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -2,7 +2,10 @@ import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { DatabaseNotFoundError } from "../errors.ts";
+import {
+  DatabaseNotFoundError,
+  DatabaseAccessDeniedError,
+} from "../errors.ts";
 
 const DEFAULT_DB_PATH = join(
   homedir(),
@@ -18,7 +21,10 @@ export function openDatabase(dbPath?: string): Database {
 
   try {
     return new Database(path, { readonly: true });
-  } catch (_error) {
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "SQLITE_AUTH") {
+      throw new DatabaseAccessDeniedError(path);
+    }
     throw new DatabaseNotFoundError(path);
   }
 }

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -2,10 +2,7 @@ import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-  DatabaseNotFoundError,
-  DatabaseAccessDeniedError,
-} from "../errors.ts";
+import { DatabaseAccessDeniedError, DatabaseNotFoundError } from "../errors.ts";
 
 const DEFAULT_DB_PATH = join(
   homedir(),
@@ -22,7 +19,11 @@ export function openDatabase(dbPath?: string): Database {
   try {
     return new Database(path, { readonly: true });
   } catch (error) {
-    if (error instanceof Error && "code" in error && error.code === "SQLITE_AUTH") {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "SQLITE_AUTH"
+    ) {
       throw new DatabaseAccessDeniedError(path);
     }
     throw new DatabaseNotFoundError(path);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -25,3 +25,13 @@ export class DatabaseNotFoundError extends AppleNotesError {
     this.name = "DatabaseNotFoundError";
   }
 }
+
+export class DatabaseAccessDeniedError extends AppleNotesError {
+  constructor(path: string) {
+    super(
+      `Access denied to NoteStore database: ${path}\n` +
+        `Grant Full Disk Access to your terminal app in System Settings → Privacy & Security → Full Disk Access.`,
+    );
+    this.name = "DatabaseAccessDeniedError";
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export type { AppleNotesOptions } from "./apple-notes.ts";
 export { AppleNotes } from "./apple-notes.ts";
 export {
   AppleNotesError,
+  DatabaseAccessDeniedError,
   DatabaseNotFoundError,
   NoteNotFoundError,
   PasswordProtectedError,


### PR DESCRIPTION
## Summary

When `bun example` fails due to missing Full Disk Access, the error incorrectly says "NoteStore database not found" even though the file exists. The actual SQLite error is `SQLITE_AUTH` (authorization denied).

This adds a `DatabaseAccessDeniedError` that detects the `SQLITE_AUTH` code and tells the user to grant Full Disk Access in System Settings, instead of the misleading "not found" message.

## Test plan

- `bun test` — all 74 tests pass
- `bun example` without FDA now shows: "Access denied… Grant Full Disk Access to your terminal app in System Settings → Privacy & Security → Full Disk Access"

🤖 Generated with [Claude Code](https://claude.com/claude-code)