### PR TITLE
Add Conductor workspace setup and teardown scripts

### DIFF
--- a/.conductor/archive.sh
+++ b/.conductor/archive.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+MAIN=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+MAIN_BRANCH=$(git -C "$MAIN" rev-parse --abbrev-ref HEAD)
+
+if [ "$MAIN_BRANCH" = "main" ]; then
+  echo "Main worktree is on main — pulling latest"
+  git -C "$MAIN" pull
+else
+  echo "Main worktree is on $MAIN_BRANCH — fetching"
+  git -C "$MAIN" fetch
+fi

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+bun install

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# Conductor workspace context
+.context/

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "bash .conductor/setup.sh",
+    "archive": "bash .conductor/archive.sh"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `conductor.json` pointing to setup and archive scripts in `.conductor/`
- Setup script runs `bun install` for dependency installation
- Archive script updates the parent worktree branch (pulls if on main, fetches otherwise)
- Adds `.context/` to `.gitignore` for Conductor workspace context files

🤖 Generated with [Claude Code](https://claude.com/claude-code)