### PR TITLE
Slim down README, move conversion details to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,84 +53,15 @@ db.close();
 
 ## API
 
-### `new AppleNotes(options?)`
+Pass `dbPath` or `containerPath` to `new AppleNotes()` to override auto-detection. Note content is returned as markdown — see [docs/markdown-conversion.md](docs/markdown-conversion.md) for the full formatting map.
 
-Opens the NoteStore.sqlite database. Options:
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `dbPath` | `string` | Auto-detected | Path to NoteStore.sqlite |
-| `containerPath` | `string` | Auto-detected | Path to Apple Notes container (for attachment resolution) |
-
-### Methods
-
-| Method | Returns | Description |
-|--------|---------|-------------|
-| `accounts()` | `Account[]` | List all accounts (iCloud, On My Mac, etc.) |
-| `folders(account?)` | `Folder[]` | List folders, optionally filtered by account |
-| `notes(options?)` | `NoteMeta[]` | List notes, optionally filtered by folder/account |
-| `search(query, options?)` | `NoteMeta[]` | Search notes by title and snippet |
-| `read(noteId)` | `NoteContent` | Read full note as markdown |
-| `read(noteId, { offset, limit })` | `NoteContentPage` | Read paginated note content |
-| `getAttachments(noteId)` | `AttachmentRef[]` | Get attachment metadata for a note |
-| `getAttachmentUrl(identifier)` | `string \| null` | Resolve attachment UUID to `file://` URL |
-| `close()` | `void` | Close the database connection |
-
-### Markdown Conversion
-
-The following Apple Notes formatting is converted to markdown:
-
-| Apple Notes | Markdown |
-|-------------|----------|
-| Title | `# Title` |
-| Heading | `## Heading` |
-| Subheading | `### Subheading` |
-| Bold | `**bold**` |
-| Italic | `*italic*` |
-| Bold + Italic | `***both***` |
-| Strikethrough | `~~struck~~` |
-| Underline | `<u>underline</u>` |
-| Code block | `` ``` `` fenced block |
-| Inline code | `` `code` `` |
-| Bullet list | `- item` |
-| Numbered list | `1. item` |
-| Checklist | `- [ ]` / `- [x]` |
-| Block quote | `> quote` |
-| Link | `[text](url)` |
-| Attachment | `![attachment](attachment:uuid)` |
-| Nested lists | Indented with 2 spaces per level |
-
-### Error Handling
-
-| Error | When |
-|-------|------|
-| `DatabaseNotFoundError` | NoteStore.sqlite not found or inaccessible (check Full Disk Access) |
-| `NoteNotFoundError` | Note ID doesn't exist |
-| `PasswordProtectedError` | Note is locked and can't be read |
-
-## How It Works
-
-Apple Notes stores data in a Core Data SQLite database at:
-
-```
-~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite
-```
-
-Note content is stored as gzip-compressed [Protocol Buffers](https://protobuf.dev/) in the `ZICNOTEDATA.ZDATA` column. This package:
-
-1. Opens the database read-only with `bun:sqlite`
-2. Discovers entity types from `Z_PRIMARYKEY` (handles schema variations across macOS versions)
-3. Decompresses ZDATA with `node:zlib`
-4. Decodes the protobuf using a reverse-engineered `.proto` schema
-5. Walks the `AttributeRun` entries to convert formatting to markdown
-
-The protobuf schema is based on research from [apple_cloud_notes_parser](https://github.com/threeplanetssoftware/apple_cloud_notes_parser), [apple-notes-liberator](https://github.com/HamburgChimps/apple-notes-liberator), and [Ciofeca Forensics](https://ciofecaforensics.com/2020/09/18/apple-notes-revisited-protobuf/).
+Errors: `DatabaseNotFoundError` (missing DB or no Full Disk Access), `NoteNotFoundError`, `PasswordProtectedError` (locked notes can't be decrypted).
 
 ## Development
 
 ```bash
 bun test              # Run test suite (74 tests)
-bun run typecheck     # TypeScript type checking
+bun run lint          # TypeScript type checking + Biome lint
 bun example           # List notes on this machine, display one at random
 bun run create-fixture # Regenerate the test fixture database
 ```
@@ -140,8 +71,6 @@ Tests run against a checked-in fixture database — no Full Disk Access needed.
 ## Limitations
 
 - **Read-only** — writing to the SQLite database directly risks iCloud sync corruption
-- **macOS only** — requires the Apple Notes database on disk
-- **Full Disk Access required** — the database is protected by macOS TCC
 - **Password-protected notes** — cannot be decrypted; throws `PasswordProtectedError`
 - **Tables** — embedded tables use a separate CRDT-based protobuf format and are not yet converted to markdown
 

--- a/docs/markdown-conversion.md
+++ b/docs/markdown-conversion.md
@@ -1,0 +1,43 @@
+# Markdown Conversion
+
+apple-notes-ts converts Apple Notes content from its internal protobuf format into standard markdown. This document describes the conversion mapping and how the underlying data is accessed.
+
+## Formatting Map
+
+| Apple Notes | Markdown |
+|-------------|----------|
+| Title | `# Title` |
+| Heading | `## Heading` |
+| Subheading | `### Subheading` |
+| Bold | `**bold**` |
+| Italic | `*italic*` |
+| Bold + Italic | `***both***` |
+| Strikethrough | `~~struck~~` |
+| Underline | `<u>underline</u>` |
+| Code block | `` ``` `` fenced block |
+| Inline code | `` `code` `` |
+| Bullet list | `- item` |
+| Numbered list | `1. item` |
+| Checklist | `- [ ]` / `- [x]` |
+| Block quote | `> quote` |
+| Link | `[text](url)` |
+| Attachment | `![attachment](attachment:uuid)` |
+| Nested lists | Indented with 2 spaces per level |
+
+## How It Works
+
+Apple Notes stores data in a Core Data SQLite database at:
+
+```
+~/Library/Group Containers/group.com.apple.notes/NoteStore.sqlite
+```
+
+Note content is stored as gzip-compressed [Protocol Buffers](https://protobuf.dev/) in the `ZICNOTEDATA.ZDATA` column. This package:
+
+1. Opens the database read-only with `bun:sqlite`
+2. Discovers entity types from `Z_PRIMARYKEY` (handles schema variations across macOS versions)
+3. Decompresses ZDATA with `node:zlib`
+4. Decodes the protobuf using a reverse-engineered `.proto` schema
+5. Walks the `AttributeRun` entries to convert formatting to markdown
+
+The protobuf schema is based on research from [apple_cloud_notes_parser](https://github.com/threeplanetssoftware/apple_cloud_notes_parser), [apple-notes-liberator](https://github.com/HamburgChimps/apple-notes-liberator), and [Ciofeca Forensics](https://ciofecaforensics.com/2020/09/18/apple-notes-revisited-protobuf/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-ts",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "TypeScript package for reading and searching Apple Notes on macOS via direct SQLite access. Includes markdown conversion and attachment support!",
   "module": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Move markdown conversion table and "How It Works" internals to `docs/markdown-conversion.md`
- Remove redundant API method/constructor tables — the Usage code example already demonstrates every method
- Deduplicate Limitations section (macOS-only and Full Disk Access already in Requirements)
- Fix stale `bun run typecheck` → `bun run lint` in Development section
- Bump version to 0.1.3

README goes from 151 lines to 80 lines while preserving all essential information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)