### PR TITLE
Add stdio MCP server for AI agent access to Apple Notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ apple-notes-ts — TypeScript package for reading and searching Apple Notes on m
 
 ## Commands
 
-- `bun test` — Run all tests (74 tests against fixture DB, no Full Disk Access needed)
+- `bun test` — Run all tests (against fixture DB, no Full Disk Access needed)
 - `bun run lint` — TypeScript type checking + Biome linting/format checking
 - `bun run format` — Auto-fix lint issues and reformat with Biome
+- `bun run mcp` — Start the stdio MCP server (requires Full Disk Access)
 - `bun example` — List notes on this machine and display one at random (requires Full Disk Access)
 - `bun run create-fixture` — Regenerate the test fixture database
 
@@ -30,6 +31,7 @@ apple-notes-ts — TypeScript package for reading and searching Apple Notes on m
 - `src/conversion/proto-to-markdown.ts` — AttributeRun[] → markdown
 - `src/database/queries.ts` — SQL queries and Mac time conversion
 - `src/database/reader.ts` — SQLite query execution and row mapping
+- `src/mcp-server.ts` — Stdio MCP server wrapping AppleNotes API as 7 tools
 - `tests/fixtures/create-test-db.ts` — Generates the test NoteStore.sqlite
 
 ## Style Type Values (ParagraphStyle.style_type)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ const url = db.getAttachmentUrl("attachment-uuid"); // file:// URL or null
 db.close();
 ```
 
+## MCP Server
+
+apple-notes-ts includes a stdio MCP server so AI agents can interact with your notes.
+
+### Configure
+
+Add to your MCP client config (e.g., Claude Desktop, Claude Code):
+
+```json
+{
+  "mcpServers": {
+    "apple-notes": {
+      "command": "bunx",
+      "args": ["apple-notes-ts"]
+    }
+  }
+}
+```
+
+### Available Tools
+
+- **list_accounts** — List all Apple Notes accounts on this Mac
+- **list_folders** — List folders, optionally filtered by account
+- **list_notes** — List notes, optionally filtered by folder/account
+- **search_notes** — Search notes by title and content
+- **read_note** — Read a note as markdown (supports pagination)
+- **get_attachments** — List attachments for a note
+- **get_attachment_url** — Get the file URL for an attachment
+
 ## API
 
 Pass `dbPath` or `containerPath` to `new AppleNotes()` to override auto-detection. Note content is returned as markdown — see [docs/markdown-conversion.md](docs/markdown-conversion.md) for the full formatting map.
@@ -60,8 +89,9 @@ Errors: `DatabaseNotFoundError` (missing DB or no Full Disk Access), `NoteNotFou
 ## Development
 
 ```bash
-bun test              # Run test suite (74 tests)
+bun test              # Run test suite
 bun run lint          # TypeScript type checking + Biome lint
+bun run mcp           # Start the MCP stdio server
 bun example           # List notes on this machine, display one at random
 bun run create-fixture # Regenerate the test fixture database
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "apple-notes-ts",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "protobufjs": "^8.0.1",
       },
       "devDependencies": {
@@ -35,6 +36,10 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.11", "", { "os": "win32", "cpu": "x64" }, "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -59,14 +64,192 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "apple-notes-ts",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "TypeScript package for reading and searching Apple Notes on macOS via direct SQLite access. Includes markdown conversion and attachment support!",
   "module": "src/index.ts",
+  "bin": {
+    "apple-notes-mcp": "src/mcp-server.ts"
+  },
   "type": "module",
   "license": "MIT",
   "files": [
@@ -22,7 +25,8 @@
     "macos",
     "sqlite",
     "typescript",
-    "notes"
+    "notes",
+    "mcp"
   ],
   "author": "Evan Tahler",
   "scripts": {
@@ -30,6 +34,7 @@
     "lint": "tsc --noEmit && biome check .",
     "format": "biome check --write .",
     "example": "bun run example.ts",
+    "mcp": "bun run src/mcp-server.ts",
     "create-fixture": "bun run tests/fixtures/create-test-db.ts"
   },
   "devDependencies": {
@@ -40,6 +45,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "protobufjs": "^8.0.1"
   }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env bun
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+import { AppleNotes, type AppleNotesOptions } from "./apple-notes.ts";
+import { AppleNotesError } from "./errors.ts";
+
+function toolResult(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+function toolError(message: string) {
+  return {
+    isError: true as const,
+    content: [{ type: "text" as const, text: message }],
+  };
+}
+
+export function createServer(options?: AppleNotesOptions) {
+  const appleNotes = new AppleNotes(options);
+
+  const server = new McpServer({
+    name: "apple-notes",
+    version: "0.2.0",
+  });
+
+  server.registerTool(
+    "list_accounts",
+    {
+      description:
+        "List all Apple Notes accounts configured on this Mac (e.g. iCloud, On My Mac). Returns each account's numeric ID and display name.",
+    },
+    async () => {
+      try {
+        return toolResult(appleNotes.accounts());
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_folders",
+    {
+      description:
+        "List Apple Notes folders. Each folder includes its name, note count, and the account it belongs to. Optionally filter to a single account.",
+      inputSchema: {
+        account: z
+          .string()
+          .optional()
+          .describe(
+            "Account name (e.g. 'iCloud') or numeric account ID to filter by.",
+          ),
+      },
+    },
+    async ({ account }) => {
+      try {
+        return toolResult(appleNotes.folders(account));
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "list_notes",
+    {
+      description:
+        "List notes ordered by most recently modified. Returns metadata only (title, snippet, dates) — use read_note to get the full content. Optionally filter by folder and/or account.",
+      inputSchema: {
+        folder: z
+          .string()
+          .optional()
+          .describe(
+            "Folder name (e.g. 'Work') or numeric folder ID to filter by.",
+          ),
+        account: z
+          .string()
+          .optional()
+          .describe(
+            "Account name (e.g. 'iCloud') or numeric account ID to filter by.",
+          ),
+      },
+    },
+    async ({ folder, account }) => {
+      try {
+        return toolResult(appleNotes.notes({ folder, account }));
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "search_notes",
+    {
+      description:
+        "Search Apple Notes by matching against note titles and text snippets. Returns metadata for matching notes — use read_note to get full content.",
+      inputSchema: {
+        query: z
+          .string()
+          .describe("Text to search for in note titles and snippets."),
+        folder: z
+          .string()
+          .optional()
+          .describe(
+            "Folder name or numeric folder ID to restrict the search to.",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Maximum number of results to return. Defaults to 50."),
+      },
+    },
+    async ({ query, folder, limit }) => {
+      try {
+        return toolResult(appleNotes.search(query, { folder, limit }));
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "read_note",
+    {
+      description:
+        "Read the full content of an Apple Note as markdown. Supports pagination for large notes — pass offset and limit to read a specific range of lines.",
+      inputSchema: {
+        noteId: z
+          .number()
+          .int()
+          .describe(
+            "Numeric note ID (from list_notes or search_notes results).",
+          ),
+        offset: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Line number to start reading from (0-based). Omit to start from the beginning.",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "Maximum number of lines to return. Omit to return the entire note. When set, response includes totalLines and hasMore fields.",
+          ),
+      },
+    },
+    async ({ noteId, offset, limit }) => {
+      try {
+        if (offset !== undefined || limit !== undefined) {
+          return toolResult(appleNotes.read(noteId, { offset, limit }));
+        }
+        return toolResult(appleNotes.read(noteId));
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_attachments",
+    {
+      description:
+        "List all attachments (images, files, etc.) for a specific note. Returns each attachment's name, content type, and local file URL if available.",
+      inputSchema: {
+        noteId: z
+          .number()
+          .int()
+          .describe("Numeric note ID to get attachments for."),
+      },
+    },
+    async ({ noteId }) => {
+      try {
+        return toolResult(appleNotes.getAttachments(noteId));
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  server.registerTool(
+    "get_attachment_url",
+    {
+      description:
+        "Resolve a local file:// URL for a specific attachment by its filename. Returns null if the attachment file is not found on disk.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Attachment filename (from get_attachments results)."),
+      },
+    },
+    async ({ name }) => {
+      try {
+        return toolResult({ url: appleNotes.getAttachmentUrl(name) });
+      } catch (e) {
+        if (e instanceof AppleNotesError) return toolError(e.message);
+        throw e;
+      }
+    },
+  );
+
+  return { server, appleNotes };
+}
+
+if (import.meta.main) {
+  const { server, appleNotes } = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  process.on("beforeExit", () => {
+    appleNotes.close();
+  });
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,398 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../src/mcp-server.ts";
+
+const FIXTURE_DB = resolve(import.meta.dir, "fixtures/NoteStore.sqlite");
+const FIXTURE_DIR = resolve(import.meta.dir, "fixtures");
+
+let client: Client;
+let cleanup: () => void;
+
+beforeAll(async () => {
+  const { server, appleNotes } = createServer({
+    dbPath: FIXTURE_DB,
+    containerPath: FIXTURE_DIR,
+  });
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  client = new Client({ name: "test-client", version: "1.0.0" });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  cleanup = () => {
+    appleNotes.close();
+  };
+});
+
+afterAll(async () => {
+  await client.close();
+  cleanup();
+});
+
+// ============================================================================
+// helper to parse tool result text content
+// ============================================================================
+
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+function parseResult(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+function getErrorText(result: any): string {
+  return result.content[0].text;
+}
+
+// ============================================================================
+// server metadata
+// ============================================================================
+
+describe("server metadata", () => {
+  test("server exposes 7 tools", async () => {
+    const { tools } = await client.listTools();
+    expect(tools).toHaveLength(7);
+  });
+
+  test("each tool has a description", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.description?.length).toBeGreaterThan(20);
+    }
+  });
+
+  test("tool names match expected list", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "get_attachment_url",
+      "get_attachments",
+      "list_accounts",
+      "list_folders",
+      "list_notes",
+      "read_note",
+      "search_notes",
+    ]);
+  });
+
+  test("tools with params have inputSchema with property descriptions", async () => {
+    const { tools } = await client.listTools();
+    const searchTool = tools.find((t) => t.name === "search_notes");
+    const props = searchTool?.inputSchema.properties as Record<
+      string,
+      { description?: string }
+    >;
+    expect(props.query?.description).toBeTruthy();
+    expect(props.folder?.description).toBeTruthy();
+    expect(props.limit?.description).toBeTruthy();
+  });
+});
+
+// ============================================================================
+// list_accounts
+// ============================================================================
+
+describe("list_accounts", () => {
+  test("returns all accounts from fixture DB", async () => {
+    const result = await client.callTool({ name: "list_accounts" });
+    const accounts = parseResult(result);
+    expect(accounts).toHaveLength(2);
+    const names = accounts.map((a: { name: string }) => a.name).sort();
+    expect(names).toEqual(["On My Mac", "iCloud"]);
+  });
+});
+
+// ============================================================================
+// list_folders
+// ============================================================================
+
+describe("list_folders", () => {
+  test("returns all folders", async () => {
+    const result = await client.callTool({
+      name: "list_folders",
+      arguments: {},
+    });
+    const folders = parseResult(result);
+    expect(folders).toHaveLength(3);
+    const names = folders.map((f: { name: string }) => f.name).sort();
+    expect(names).toEqual(["Notes", "Personal", "Work"]);
+  });
+
+  test("filters by account name", async () => {
+    const result = await client.callTool({
+      name: "list_folders",
+      arguments: { account: "iCloud" },
+    });
+    const folders = parseResult(result);
+    for (const f of folders) {
+      expect(f.accountName).toBe("iCloud");
+    }
+  });
+});
+
+// ============================================================================
+// list_notes
+// ============================================================================
+
+describe("list_notes", () => {
+  test("returns all notes", async () => {
+    const result = await client.callTool({ name: "list_notes", arguments: {} });
+    const notes = parseResult(result);
+    expect(notes.length).toBeGreaterThan(0);
+  });
+
+  test("filters by folder", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: { folder: "Work" },
+    });
+    const notes = parseResult(result);
+    for (const n of notes) {
+      expect(n.folderName).toBe("Work");
+    }
+  });
+
+  test("filters by account", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: { account: "iCloud" },
+    });
+    const notes = parseResult(result);
+    for (const n of notes) {
+      expect(n.accountName).toBe("iCloud");
+    }
+  });
+});
+
+// ============================================================================
+// search_notes
+// ============================================================================
+
+describe("search_notes", () => {
+  test("returns matching notes", async () => {
+    const result = await client.callTool({
+      name: "search_notes",
+      arguments: { query: "Headings" },
+    });
+    const notes = parseResult(result);
+    expect(notes.length).toBeGreaterThan(0);
+  });
+
+  test("respects limit parameter", async () => {
+    const result = await client.callTool({
+      name: "search_notes",
+      arguments: { query: "note", limit: 2 },
+    });
+    const notes = parseResult(result);
+    expect(notes.length).toBeLessThanOrEqual(2);
+  });
+
+  test("returns empty array for no matches", async () => {
+    const result = await client.callTool({
+      name: "search_notes",
+      arguments: { query: "xyznonexistent999" },
+    });
+    const notes = parseResult(result);
+    expect(notes).toEqual([]);
+  });
+});
+
+// ============================================================================
+// read_note
+// ============================================================================
+
+describe("read_note", () => {
+  let validNoteId: number;
+
+  beforeAll(async () => {
+    const result = await client.callTool({ name: "list_notes", arguments: {} });
+    const notes = parseResult(result);
+    const readable = notes.find(
+      (n: { isPasswordProtected: boolean }) => !n.isPasswordProtected,
+    );
+    validNoteId = readable.id;
+  });
+
+  test("returns note content as markdown", async () => {
+    const result = await client.callTool({
+      name: "read_note",
+      arguments: { noteId: validNoteId },
+    });
+    const note = parseResult(result);
+    expect(note.meta).toBeDefined();
+    expect(typeof note.markdown).toBe("string");
+    expect(note.markdown.length).toBeGreaterThan(0);
+  });
+
+  test("supports pagination with offset and limit", async () => {
+    const result = await client.callTool({
+      name: "read_note",
+      arguments: { noteId: validNoteId, offset: 0, limit: 2 },
+    });
+    const page = parseResult(result);
+    expect(page.offset).toBe(0);
+    expect(page.limit).toBe(2);
+    expect(typeof page.totalLines).toBe("number");
+    expect(typeof page.hasMore).toBe("boolean");
+  });
+
+  test("returns error for nonexistent note ID", async () => {
+    const result = await client.callTool({
+      name: "read_note",
+      arguments: { noteId: 999999 },
+    });
+    expect(result.isError).toBe(true);
+    expect(getErrorText(result)).toContain("Note not found");
+  });
+
+  test("returns error for password-protected note", async () => {
+    const listResult = await client.callTool({
+      name: "list_notes",
+      arguments: {},
+    });
+    const notes = parseResult(listResult);
+    const locked = notes.find(
+      (n: { isPasswordProtected: boolean }) => n.isPasswordProtected,
+    );
+    if (!locked) return; // skip if no locked notes in fixture
+
+    const result = await client.callTool({
+      name: "read_note",
+      arguments: { noteId: locked.id },
+    });
+    expect(result.isError).toBe(true);
+    expect(getErrorText(result)).toContain("password protected");
+  });
+});
+
+// ============================================================================
+// get_attachments
+// ============================================================================
+
+describe("get_attachments", () => {
+  test("returns attachments for a note", async () => {
+    const listResult = await client.callTool({
+      name: "list_notes",
+      arguments: {},
+    });
+    const notes = parseResult(listResult);
+    const result = await client.callTool({
+      name: "get_attachments",
+      arguments: { noteId: notes[0].id },
+    });
+    const attachments = parseResult(result);
+    expect(Array.isArray(attachments)).toBe(true);
+  });
+});
+
+// ============================================================================
+// get_attachment_url
+// ============================================================================
+
+describe("get_attachment_url", () => {
+  test("returns null URL for unknown attachment name", async () => {
+    const result = await client.callTool({
+      name: "get_attachment_url",
+      arguments: { name: "nonexistent-file.png" },
+    });
+    const data = parseResult(result);
+    expect(data.url).toBeNull();
+  });
+});
+
+// ============================================================================
+// input validation
+// ============================================================================
+
+describe("input validation", () => {
+  test("search_notes rejects missing required query param", async () => {
+    try {
+      const result = await client.callTool({
+        name: "search_notes",
+        arguments: {},
+      });
+      // If it doesn't throw, it should be an error result
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      // Protocol-level error is also acceptable
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("read_note rejects missing required noteId param", async () => {
+    try {
+      const result = await client.callTool({
+        name: "read_note",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("read_note rejects non-integer noteId", async () => {
+    try {
+      const result = await client.callTool({
+        name: "read_note",
+        arguments: { noteId: "abc" },
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("search_notes rejects limit less than 1", async () => {
+    try {
+      const result = await client.callTool({
+        name: "search_notes",
+        arguments: { query: "test", limit: 0 },
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("read_note rejects negative offset", async () => {
+    try {
+      const result = await client.callTool({
+        name: "read_note",
+        arguments: { noteId: 1, offset: -1 },
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("get_attachments rejects missing noteId", async () => {
+    try {
+      const result = await client.callTool({
+        name: "get_attachments",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+
+  test("get_attachment_url rejects missing name", async () => {
+    try {
+      const result = await client.callTool({
+        name: "get_attachment_url",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a stdio MCP server (`src/mcp-server.ts`) exposing 7 tools that wrap the `AppleNotes` API: `list_accounts`, `list_folders`, `list_notes`, `search_notes`, `read_note`, `get_attachments`, `get_attachment_url`
- Each tool has detailed descriptions, per-argument Zod schemas with type/range validation, and structured error handling for `NoteNotFoundError`/`PasswordProtectedError`
- 26 new tests using `InMemoryTransport` covering all tools, metadata, and input validation
- Adds `bin` entry (`apple-notes-mcp`), `bun run mcp` script, and updates README/CLAUDE.md with configuration and usage docs
- Version bumped to 0.2.0

## Test plan

- [x] `bun test` — 100 tests pass (74 existing + 26 new MCP server tests)
- [x] `bun run lint` — TypeScript + Biome checks pass
- [ ] Manual test with `npx @modelcontextprotocol/inspector` to verify tool discovery and execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)