### PR TITLE
Rename get_attachments to list_attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ console.log(page.hasMore);       // true if more lines follow
 console.log(page.totalLines);    // total line count
 
 // Attachments
-const attachments = db.getAttachments(noteId);
+const attachments = db.listAttachments(noteId);
 const url = db.getAttachmentUrl("attachment-uuid"); // file:// URL or null
 
 // Cleanup
@@ -77,7 +77,7 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 - **list_notes** — List notes, optionally filtered by folder/account
 - **search_notes** — Search notes by title and content
 - **read_note** — Read a note as markdown (supports pagination)
-- **get_attachments** — List attachments for a note
+- **list_attachments** — List attachments for a note
 - **get_attachment_url** — Get the file URL for an attachment
 
 ## API

--- a/example.ts
+++ b/example.ts
@@ -62,7 +62,7 @@ if (readable.length === 0) {
   console.log(content.markdown);
 
   // Show attachment info if any
-  const attachments = db.getAttachments(pick.id);
+  const attachments = db.listAttachments(pick.id);
   if (attachments.length > 0) {
     console.log();
     console.log(`Attachments (${attachments.length}):`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-ts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript package for reading and searching Apple Notes on macOS via direct SQLite access. Includes markdown conversion and attachment support!",
   "module": "src/index.ts",
   "bin": {

--- a/src/apple-notes.ts
+++ b/src/apple-notes.ts
@@ -89,8 +89,8 @@ export class AppleNotes {
     return this.reader.listNotes(options).map((r) => r.meta);
   }
 
-  getAttachments(noteId: number): AttachmentRef[] {
-    const refs = this.reader.getAttachments(noteId);
+  listAttachments(noteId: number): AttachmentRef[] {
+    const refs = this.reader.listAttachments(noteId);
     return refs.map((ref) => ({
       ...ref,
       url: this.attachmentResolver.resolve(ref.name),

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -233,7 +233,7 @@ export class NoteReader {
     return results;
   }
 
-  getAttachments(noteId: number): AttachmentRef[] {
+  listAttachments(noteId: number): AttachmentRef[] {
     const rows = this.db
       .query(Q.GET_ATTACHMENTS)
       .all(noteId, this.entityTypes.attachment) as AttachmentRow[];

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -175,7 +175,7 @@ export function createServer(options?: AppleNotesOptions) {
   );
 
   server.registerTool(
-    "get_attachments",
+    "list_attachments",
     {
       description:
         "List all attachments (images, files, etc.) for a specific note. Returns each attachment's name, content type, and local file URL if available.",
@@ -188,7 +188,7 @@ export function createServer(options?: AppleNotesOptions) {
     },
     async ({ noteId }) => {
       try {
-        return toolResult(appleNotes.getAttachments(noteId));
+        return toolResult(appleNotes.listAttachments(noteId));
       } catch (e) {
         if (e instanceof AppleNotesError) return toolError(e.message);
         throw e;
@@ -204,7 +204,7 @@ export function createServer(options?: AppleNotesOptions) {
       inputSchema: {
         name: z
           .string()
-          .describe("Attachment filename (from get_attachments results)."),
+          .describe("Attachment filename (from list_attachments results)."),
       },
     },
     async ({ name }) => {

--- a/tests/apple-notes.test.ts
+++ b/tests/apple-notes.test.ts
@@ -275,19 +275,19 @@ describe("read with pagination", () => {
 });
 
 // ============================================================================
-// getAttachments()
+// listAttachments()
 // ============================================================================
 
-describe("getAttachments", () => {
+describe("listAttachments", () => {
   test("returns attachments for a note with attachments", () => {
     // Note 110 has an attachment
-    const attachments = db.getAttachments(110);
+    const attachments = db.listAttachments(110);
     expect(attachments.length).toBeGreaterThan(0);
     expect(attachments[0]?.contentType).toBe("public.jpeg");
   });
 
   test("returns empty array for note without attachments", () => {
-    const attachments = db.getAttachments(100);
+    const attachments = db.listAttachments(100);
     expect(attachments).toHaveLength(0);
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -71,8 +71,8 @@ describe("server metadata", () => {
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "get_attachment_url",
-      "get_attachments",
       "list_accounts",
+      "list_attachments",
       "list_folders",
       "list_notes",
       "read_note",
@@ -271,10 +271,10 @@ describe("read_note", () => {
 });
 
 // ============================================================================
-// get_attachments
+// list_attachments
 // ============================================================================
 
-describe("get_attachments", () => {
+describe("list_attachments", () => {
   test("returns attachments for a note", async () => {
     const listResult = await client.callTool({
       name: "list_notes",
@@ -282,7 +282,7 @@ describe("get_attachments", () => {
     });
     const notes = parseResult(listResult);
     const result = await client.callTool({
-      name: "get_attachments",
+      name: "list_attachments",
       arguments: { noteId: notes[0].id },
     });
     const attachments = parseResult(result);
@@ -372,10 +372,10 @@ describe("input validation", () => {
     }
   });
 
-  test("get_attachments rejects missing noteId", async () => {
+  test("list_attachments rejects missing noteId", async () => {
     try {
       const result = await client.callTool({
-        name: "get_attachments",
+        name: "list_attachments",
         arguments: {},
       });
       expect(result.isError).toBe(true);


### PR DESCRIPTION
## Summary
- Renames the MCP tool `get_attachments` → `list_attachments` and the TypeScript API method `getAttachments` → `listAttachments` to align with the existing `list_*` naming convention (`list_accounts`, `list_folders`, `list_notes`)
- Updates all references across source, tests, README, and example
- Bumps version to 0.2.1

## Test plan
- [x] `bun run lint` passes
- [x] `bun test` — all 100 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)