### PR TITLE
Fix createdAt always showing epoch 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-ts",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript package for reading and searching Apple Notes on macOS via direct SQLite access. Includes markdown conversion and attachment support!",
   "module": "src/index.ts",
   "bin": {

--- a/src/database/queries.ts
+++ b/src/database/queries.ts
@@ -2,6 +2,11 @@
 // Offset from Unix epoch (1970-01-01) in seconds
 export const MAC_EPOCH_OFFSET = 978307200;
 
+export interface DateColumns {
+  createdAt: string;
+  modifiedAt: string;
+}
+
 export function macTimeToDate(macTime: number | null): Date {
   if (macTime == null) return new Date(0);
   return new Date((macTime + MAC_EPOCH_OFFSET) * 1000);
@@ -47,14 +52,14 @@ export const COUNT_NOTES_PER_FOLDER = `
   GROUP BY n.ZFOLDER
 `;
 
-export const LIST_NOTES = `
+export const listNotes = (dateCols: DateColumns) => `
   SELECT
     n.Z_PK as id,
     n.ZTITLE1 as title,
     n.ZSNIPPET as snippet,
     n.ZFOLDER as folderId,
-    n.ZCREATIONDATE1 as createdAt,
-    n.ZMODIFICATIONDATE1 as modifiedAt,
+    n.${dateCols.createdAt} as createdAt,
+    n.${dateCols.modifiedAt} as modifiedAt,
     n.ZISPASSWORDPROTECTED as isPasswordProtected,
     nd.ZDATA as zdata,
     nd.Z_PK as noteDataId
@@ -63,17 +68,17 @@ export const LIST_NOTES = `
   WHERE n.ZTITLE1 IS NOT NULL
     AND n.ZMARKEDFORDELETION != 1
     AND n.Z_ENT = ?
-  ORDER BY n.ZMODIFICATIONDATE1 DESC
+  ORDER BY n.${dateCols.modifiedAt} DESC
 `;
 
-export const GET_NOTE = `
+export const getNote = (dateCols: DateColumns) => `
   SELECT
     n.Z_PK as id,
     n.ZTITLE1 as title,
     n.ZSNIPPET as snippet,
     n.ZFOLDER as folderId,
-    n.ZCREATIONDATE1 as createdAt,
-    n.ZMODIFICATIONDATE1 as modifiedAt,
+    n.${dateCols.createdAt} as createdAt,
+    n.${dateCols.modifiedAt} as modifiedAt,
     n.ZISPASSWORDPROTECTED as isPasswordProtected,
     nd.ZDATA as zdata,
     nd.Z_PK as noteDataId
@@ -82,37 +87,37 @@ export const GET_NOTE = `
   WHERE n.Z_PK = ?
 `;
 
-export const SEARCH_BY_TITLE = `
+export const searchByTitle = (dateCols: DateColumns) => `
   SELECT
     n.Z_PK as id,
     n.ZTITLE1 as title,
     n.ZSNIPPET as snippet,
     n.ZFOLDER as folderId,
-    n.ZCREATIONDATE1 as createdAt,
-    n.ZMODIFICATIONDATE1 as modifiedAt,
+    n.${dateCols.createdAt} as createdAt,
+    n.${dateCols.modifiedAt} as modifiedAt,
     n.ZISPASSWORDPROTECTED as isPasswordProtected
   FROM ZICCLOUDSYNCINGOBJECT n
   WHERE n.ZTITLE1 LIKE ?
     AND n.ZMARKEDFORDELETION != 1
     AND n.Z_ENT = ?
-  ORDER BY n.ZMODIFICATIONDATE1 DESC
+  ORDER BY n.${dateCols.modifiedAt} DESC
   LIMIT ?
 `;
 
-export const SEARCH_BY_SNIPPET = `
+export const searchBySnippet = (dateCols: DateColumns) => `
   SELECT
     n.Z_PK as id,
     n.ZTITLE1 as title,
     n.ZSNIPPET as snippet,
     n.ZFOLDER as folderId,
-    n.ZCREATIONDATE1 as createdAt,
-    n.ZMODIFICATIONDATE1 as modifiedAt,
+    n.${dateCols.createdAt} as createdAt,
+    n.${dateCols.modifiedAt} as modifiedAt,
     n.ZISPASSWORDPROTECTED as isPasswordProtected
   FROM ZICCLOUDSYNCINGOBJECT n
   WHERE (n.ZTITLE1 LIKE ? OR n.ZSNIPPET LIKE ?)
     AND n.ZMARKEDFORDELETION != 1
     AND n.Z_ENT = ?
-  ORDER BY n.ZMODIFICATIONDATE1 DESC
+  ORDER BY n.${dateCols.modifiedAt} DESC
   LIMIT ?
 `;
 

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -7,6 +7,7 @@ import type {
   NoteMeta,
   SearchOptions,
 } from "../types.ts";
+import type { DateColumns } from "./queries.ts";
 import * as Q from "./queries.ts";
 
 interface EntityTypes {
@@ -14,6 +15,10 @@ interface EntityTypes {
   folder: number;
   note: number;
   attachment: number;
+}
+
+interface ColumnInfoRow {
+  name: string;
 }
 
 interface NoteRow {
@@ -55,6 +60,7 @@ interface EntityTypeRow {
 export class NoteReader {
   private db: Database;
   private entityTypes: EntityTypes;
+  private dateColumns: DateColumns;
   private folderCache: Map<number, { name: string; accountId: number }> =
     new Map();
   private accountCache: Map<number, string> = new Map();
@@ -62,6 +68,7 @@ export class NoteReader {
   constructor(db: Database) {
     this.db = db;
     this.entityTypes = this.discoverEntityTypes();
+    this.dateColumns = this.discoverDateColumns();
     this.buildCaches();
   }
 
@@ -92,6 +99,42 @@ export class NoteReader {
       note: types.note ?? 0,
       attachment: types.attachment ?? 0,
     };
+  }
+
+  private discoverDateColumns(): DateColumns {
+    const rows = this.db
+      .query("PRAGMA table_info(ZICCLOUDSYNCINGOBJECT)")
+      .all() as ColumnInfoRow[];
+    const columns = rows.map((r) => r.name);
+
+    // Core Data column suffixes vary by macOS version.
+    // Find all matching date columns, then pick the one with actual data.
+    const creationCols = columns.filter((c) => c.startsWith("ZCREATIONDATE"));
+    const modificationCols = columns.filter((c) =>
+      c.startsWith("ZMODIFICATIONDATE"),
+    );
+
+    return {
+      createdAt: this.pickDateColumn(creationCols) ?? "ZCREATIONDATE1",
+      modifiedAt: this.pickDateColumn(modificationCols) ?? "ZMODIFICATIONDATE1",
+    };
+  }
+
+  private pickDateColumn(candidates: string[]): string | null {
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0] ?? null;
+
+    // Multiple columns exist — pick the one that has non-NULL data
+    for (const col of candidates) {
+      const row = this.db
+        .query(
+          `SELECT ${col} as v FROM ZICCLOUDSYNCINGOBJECT WHERE ${col} IS NOT NULL LIMIT 1`,
+        )
+        .get() as { v: number } | null;
+      if (row) return col;
+    }
+
+    return candidates[0] ?? null;
   }
 
   private buildCaches(): void {
@@ -176,7 +219,7 @@ export class NoteReader {
     options?: ListNotesOptions,
   ): { meta: NoteMeta; zdata: Buffer | null }[] {
     const rows = this.db
-      .query(Q.LIST_NOTES)
+      .query(Q.listNotes(this.dateColumns))
       .all(this.entityTypes.note) as NoteRow[];
 
     let results = rows.map((r) => ({
@@ -204,7 +247,9 @@ export class NoteReader {
   }
 
   getNote(noteId: number): { meta: NoteMeta; zdata: Buffer | null } | null {
-    const row = this.db.query(Q.GET_NOTE).get(noteId) as NoteRow | null;
+    const row = this.db
+      .query(Q.getNote(this.dateColumns))
+      .get(noteId) as NoteRow | null;
     if (!row) return null;
     return {
       meta: this.rowToMeta(row),
@@ -217,7 +262,7 @@ export class NoteReader {
     const limit = options?.limit ?? 50;
 
     const rows = this.db
-      .query(Q.SEARCH_BY_SNIPPET)
+      .query(Q.searchBySnippet(this.dateColumns))
       .all(pattern, pattern, this.entityTypes.note, limit) as NoteRow[];
 
     let results = rows.map((r) => this.rowToMeta(r));


### PR DESCRIPTION
## Summary
- Note `createdAt` dates always showed `1970-01-01T00:00:00.000Z` because the hardcoded `ZCREATIONDATE1` column was NULL in some real Apple Notes databases
- Apple Notes uses Core Data, where column suffixes vary by macOS version — the actual data may live in `ZCREATIONDATE` instead of `ZCREATIONDATE1`
- Added dynamic date column discovery at init time using `PRAGMA table_info`, picking the column that has non-NULL data when multiple candidates exist
- Converted 4 static SQL query constants into functions that accept discovered column names

## Test plan
- [x] All 103 existing tests pass
- [x] Lint and type checking pass
- [ ] Manual verification with real Apple Notes database — `createdAt` should show actual dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)