### PR TITLE
Add sort, search, and limit options to list_notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ const db = new AppleNotes();
 const accounts = db.accounts();
 const folders = db.folders();
 
-// List all notes (or filter by folder)
+// List notes (filter, sort, search, limit)
 const allNotes = db.notes();
 const workNotes = db.notes({ folder: "Work" });
+const recent = db.notes({ search: "meeting", sortBy: "modifiedAt", order: "desc", limit: 10 });
 
 // Search by title or snippet
 const results = db.search("meeting notes");
@@ -74,7 +75,7 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 
 - **list_accounts** — List all Apple Notes accounts on this Mac
 - **list_folders** — List folders, optionally filtered by account
-- **list_notes** — List notes, optionally filtered by folder/account
+- **list_notes** — List notes with optional filtering (folder, account, text search), sorting (title, createdAt, modifiedAt), and limit
 - **search_notes** — Search notes by title and content
 - **read_note** — Read a note as markdown (supports pagination)
 - **list_attachments** — List attachments for a note

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apple-notes-ts",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript package for reading and searching Apple Notes on macOS via direct SQLite access. Includes markdown conversion and attachment support!",
   "module": "src/index.ts",
   "bin": {

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -200,6 +200,38 @@ export class NoteReader {
       );
     }
 
+    if (options?.search) {
+      const q = options.search.toLowerCase();
+      results = results.filter(
+        (r) =>
+          r.meta.title.toLowerCase().includes(q) ||
+          r.meta.snippet.toLowerCase().includes(q),
+      );
+    }
+
+    const sortBy = options?.sortBy ?? "modifiedAt";
+    const order = options?.order ?? "desc";
+    const mul = order === "asc" ? 1 : -1;
+
+    results.sort((a, b) => {
+      switch (sortBy) {
+        case "title":
+          return mul * a.meta.title.localeCompare(b.meta.title);
+        case "createdAt":
+          return (
+            mul * (a.meta.createdAt.getTime() - b.meta.createdAt.getTime())
+          );
+        default:
+          return (
+            mul * (a.meta.modifiedAt.getTime() - b.meta.modifiedAt.getTime())
+          );
+      }
+    });
+
+    if (options?.limit != null && options.limit > 0) {
+      results = results.slice(0, options.limit);
+    }
+
     return results;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ export type {
   NoteContentPage,
   NoteId,
   NoteMeta,
+  NoteSortField,
   PaginationOptions,
   SearchOptions,
+  SortOrder,
 } from "./types.ts";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -71,7 +71,7 @@ export function createServer(options?: AppleNotesOptions) {
     "list_notes",
     {
       description:
-        "List notes ordered by most recently modified. Returns metadata only (title, snippet, dates) — use read_note to get the full content. Optionally filter by folder and/or account.",
+        "List notes with optional filtering, sorting, and limiting. Returns metadata only (title, snippet, dates) — use read_note to get full content.",
       inputSchema: {
         folder: z
           .string()
@@ -85,11 +85,36 @@ export function createServer(options?: AppleNotesOptions) {
           .describe(
             "Account name (e.g. 'iCloud') or numeric account ID to filter by.",
           ),
+        search: z
+          .string()
+          .optional()
+          .describe(
+            "Text to filter notes by, matched case-insensitively against title and snippet.",
+          ),
+        sortBy: z
+          .enum(["title", "createdAt", "modifiedAt"])
+          .optional()
+          .describe("Field to sort results by. Defaults to 'modifiedAt'."),
+        order: z
+          .enum(["asc", "desc"])
+          .optional()
+          .describe(
+            "Sort direction. Defaults to 'desc' (newest first for date sorts, Z-A for title).",
+          ),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe("Maximum number of notes to return."),
       },
     },
-    async ({ folder, account }) => {
+    async ({ folder, account, search, sortBy, order, limit }) => {
       try {
-        return toolResult(appleNotes.notes({ folder, account }));
+        return toolResult(
+          appleNotes.notes({ folder, account, search, sortBy, order, limit }),
+        );
       } catch (e) {
         if (e instanceof AppleNotesError) return toolError(e.message);
         throw e;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,9 @@ export interface AttachmentRef {
   url: string | null;
 }
 
+export type NoteSortField = "title" | "createdAt" | "modifiedAt";
+export type SortOrder = "asc" | "desc";
+
 export interface SearchOptions {
   folder?: string;
   limit?: number;
@@ -59,6 +62,10 @@ export interface SearchOptions {
 export interface ListNotesOptions {
   folder?: string;
   account?: string;
+  search?: string;
+  sortBy?: NoteSortField;
+  order?: SortOrder;
+  limit?: number;
 }
 
 export interface PaginationOptions {

--- a/tests/apple-notes.test.ts
+++ b/tests/apple-notes.test.ts
@@ -98,6 +98,87 @@ describe("notes", () => {
     expect(secret).toBeDefined();
     expect(secret?.isPasswordProtected).toBe(true);
   });
+
+  test("sorts by title ascending", () => {
+    const titles = db
+      .notes({ sortBy: "title", order: "asc" })
+      .map((n) => n.title);
+    expect(titles.length).toBeGreaterThan(1);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).toEqual(sorted);
+  });
+
+  test("sorts by title descending", () => {
+    const titles = db
+      .notes({ sortBy: "title", order: "desc" })
+      .map((n) => n.title);
+    expect(titles.length).toBeGreaterThan(1);
+    const sorted = [...titles].sort((a, b) => b.localeCompare(a));
+    expect(titles).toEqual(sorted);
+  });
+
+  test("sorts by createdAt ascending", () => {
+    const times = db
+      .notes({ sortBy: "createdAt", order: "asc" })
+      .map((n) => n.createdAt.getTime());
+    expect(times.length).toBeGreaterThan(1);
+    const sorted = [...times].sort((a, b) => a - b);
+    expect(times).toEqual(sorted);
+  });
+
+  test("defaults to modifiedAt descending", () => {
+    const times = db.notes().map((n) => n.modifiedAt.getTime());
+    expect(times.length).toBeGreaterThan(1);
+    const sorted = [...times].sort((a, b) => b - a);
+    expect(times).toEqual(sorted);
+  });
+
+  test("search filters by title", () => {
+    const notes = db.notes({ search: "Simple" });
+    expect(notes.length).toBeGreaterThan(0);
+    expect(notes.some((n) => n.title === "Simple Note")).toBe(true);
+  });
+
+  test("search is case-insensitive", () => {
+    const notes = db.notes({ search: "simple" });
+    expect(notes.some((n) => n.title === "Simple Note")).toBe(true);
+  });
+
+  test("search returns empty for non-matching query", () => {
+    const notes = db.notes({ search: "xyznonexistent123" });
+    expect(notes).toHaveLength(0);
+  });
+
+  test("search combined with folder filter", () => {
+    const notes = db.notes({ search: "Note", folder: "Work" });
+    for (const n of notes) {
+      expect(n.folderName).toBe("Work");
+    }
+  });
+
+  test("search combined with sort", () => {
+    const titles = db
+      .notes({ search: "Note", sortBy: "title", order: "asc" })
+      .map((n) => n.title);
+    expect(titles.length).toBeGreaterThan(1);
+    const sorted = [...titles].sort((a, b) => a.localeCompare(b));
+    expect(titles).toEqual(sorted);
+  });
+
+  test("limit restricts result count", () => {
+    const all = db.notes();
+    const limited = db.notes({ limit: 3 });
+    expect(limited).toHaveLength(3);
+    expect(limited.length).toBeLessThan(all.length);
+  });
+
+  test("limit with sort returns correct subset", () => {
+    const allSorted = db.notes({ sortBy: "title", order: "asc" });
+    const limited = db.notes({ sortBy: "title", order: "asc", limit: 2 });
+    expect(limited).toHaveLength(2);
+    expect(limited[0]?.title).toBe(allSorted[0]?.title);
+    expect(limited[1]?.title).toBe(allSorted[1]?.title);
+  });
 });
 
 // ============================================================================

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -167,6 +167,63 @@ describe("list_notes", () => {
       expect(n.accountName).toBe("iCloud");
     }
   });
+
+  test("sorts by title ascending", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: { sortBy: "title", order: "asc" },
+    });
+    const notes = parseResult(result);
+    for (let i = 1; i < notes.length; i++) {
+      expect(
+        notes[i].title.localeCompare(notes[i - 1].title),
+      ).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test("filters by search text", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: { search: "Simple" },
+    });
+    const notes = parseResult(result);
+    expect(notes.length).toBeGreaterThan(0);
+    expect(
+      notes.some((n: { title: string }) => n.title === "Simple Note"),
+    ).toBe(true);
+  });
+
+  test("applies limit", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: { limit: 2 },
+    });
+    const notes = parseResult(result);
+    expect(notes.length).toBeLessThanOrEqual(2);
+  });
+
+  test("combines search, sort, folder, and limit", async () => {
+    const result = await client.callTool({
+      name: "list_notes",
+      arguments: {
+        search: "Note",
+        sortBy: "title",
+        order: "asc",
+        limit: 3,
+        folder: "Work",
+      },
+    });
+    const notes = parseResult(result);
+    expect(notes.length).toBeLessThanOrEqual(3);
+    for (const n of notes) {
+      expect(n.folderName).toBe("Work");
+    }
+    for (let i = 1; i < notes.length; i++) {
+      expect(
+        notes[i].title.localeCompare(notes[i - 1].title),
+      ).toBeGreaterThanOrEqual(0);
+    }
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Extends `ListNotesOptions` and the `list_notes` MCP tool with `search`, `sortBy`, `order`, and `limit` parameters
- Search is case-insensitive against title and snippet; sort supports title, createdAt, and modifiedAt in asc/desc order
- All new options are optional with backward-compatible defaults (modifiedAt desc, no filter, no limit)
- Adds 15 new tests covering sorting, search filtering, limit, and combinations across both the API and MCP layers
- Bumps version to 0.4.0

## Test plan

- [x] `bun test` — all 118 tests pass
- [x] `bun run lint` — no type or lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)