### PR TITLE
DRY up shared code between Notes and Messages modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "bin": {

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,0 +1,27 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "node:fs";
+import { DatabaseAccessDeniedError, DatabaseNotFoundError } from "../errors.ts";
+
+export function openDatabase(
+  dbPath: string | undefined,
+  defaultPath: string,
+): Database {
+  const path = dbPath ?? defaultPath;
+
+  if (!existsSync(path)) {
+    throw new DatabaseNotFoundError(path);
+  }
+
+  try {
+    return new Database(path, { readonly: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "SQLITE_AUTH"
+    ) {
+      throw new DatabaseAccessDeniedError(path);
+    }
+    throw new DatabaseNotFoundError(path);
+  }
+}

--- a/src/database/timestamps.ts
+++ b/src/database/timestamps.ts
@@ -1,0 +1,23 @@
+// Mac Absolute Time epoch: 2001-01-01 00:00:00 UTC
+// Offset from Unix epoch (1970-01-01) in seconds
+export const MAC_EPOCH_OFFSET = 978307200;
+
+// Notes timestamps are in seconds since 2001-01-01
+export function macTimeToDate(macTime: number | null): Date {
+  if (macTime == null) return new Date(0);
+  return new Date((macTime + MAC_EPOCH_OFFSET) * 1000);
+}
+
+export function dateToMacTime(date: Date): number {
+  return date.getTime() / 1000 - MAC_EPOCH_OFFSET;
+}
+
+// Messages timestamps are in nanoseconds since 2001-01-01
+export function macNanosToDate(nanos: number | null): Date {
+  if (nanos == null || nanos === 0) return new Date(0);
+  return new Date((nanos / 1e9 + MAC_EPOCH_OFFSET) * 1000);
+}
+
+export function dateToMacNanos(date: Date): number {
+  return (date.getTime() / 1000 - MAC_EPOCH_OFFSET) * 1e9;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,11 +24,15 @@ export class DatabaseAccessDeniedError extends MacOSError {
   }
 
   openSettings(): void {
-    Bun.spawn([
-      "open",
-      "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-    ]);
+    openFullDiskAccessSettings();
   }
+}
+
+export function openFullDiskAccessSettings(): void {
+  Bun.spawn([
+    "open",
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+  ]);
 }
 
 function detectTerminalApp(): string | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,10 @@ export type {
   NotesOptions,
   PaginationOptions,
   SearchOptions,
-  SortOrder,
 } from "./notes/index.ts";
 export {
   NoteNotFoundError,
   Notes,
   PasswordProtectedError,
 } from "./notes/index.ts";
+export type { SortOrder } from "./types.ts";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -20,6 +20,15 @@ function toolError(message: string) {
   };
 }
 
+function wrapTool<T>(fn: () => T) {
+  try {
+    return toolResult(fn());
+  } catch (e) {
+    if (e instanceof MacOSError) return toolError(e.message);
+    throw e;
+  }
+}
+
 export interface ServerOptions {
   notes?: NotesOptions;
   messages?: MessagesOptions;
@@ -44,14 +53,7 @@ export function createServer(options?: ServerOptions) {
       description:
         "List all Apple Notes accounts configured on this Mac (e.g. iCloud, On My Mac). Returns each account's numeric ID and display name.",
     },
-    async () => {
-      try {
-        return toolResult(notes.accounts());
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async () => wrapTool(() => notes.accounts()),
   );
 
   server.registerTool(
@@ -68,14 +70,7 @@ export function createServer(options?: ServerOptions) {
           ),
       },
     },
-    async ({ account }) => {
-      try {
-        return toolResult(notes.folders(account));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ account }) => wrapTool(() => notes.folders(account)),
   );
 
   server.registerTool(
@@ -121,16 +116,10 @@ export function createServer(options?: ServerOptions) {
           .describe("Maximum number of notes to return."),
       },
     },
-    async ({ folder, account, search, sortBy, order, limit }) => {
-      try {
-        return toolResult(
-          notes.notes({ folder, account, search, sortBy, order, limit }),
-        );
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ folder, account, search, sortBy, order, limit }) =>
+      wrapTool(() =>
+        notes.notes({ folder, account, search, sortBy, order, limit }),
+      ),
   );
 
   server.registerTool(
@@ -157,14 +146,8 @@ export function createServer(options?: ServerOptions) {
           .describe("Maximum number of results to return. Defaults to 50."),
       },
     },
-    async ({ query, folder, limit }) => {
-      try {
-        return toolResult(notes.search(query, { folder, limit }));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ query, folder, limit }) =>
+      wrapTool(() => notes.search(query, { folder, limit })),
   );
 
   server.registerTool(
@@ -197,17 +180,13 @@ export function createServer(options?: ServerOptions) {
           ),
       },
     },
-    async ({ noteId, offset, limit }) => {
-      try {
+    async ({ noteId, offset, limit }) =>
+      wrapTool(() => {
         if (offset !== undefined || limit !== undefined) {
-          return toolResult(notes.read(noteId, { offset, limit }));
+          return notes.read(noteId, { offset, limit });
         }
-        return toolResult(notes.read(noteId));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+        return notes.read(noteId);
+      }),
   );
 
   server.registerTool(
@@ -222,14 +201,7 @@ export function createServer(options?: ServerOptions) {
           .describe("Numeric note ID to get attachments for."),
       },
     },
-    async ({ noteId }) => {
-      try {
-        return toolResult(notes.listAttachments(noteId));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ noteId }) => wrapTool(() => notes.listAttachments(noteId)),
   );
 
   server.registerTool(
@@ -243,14 +215,7 @@ export function createServer(options?: ServerOptions) {
           .describe("Attachment filename (from list_attachments results)."),
       },
     },
-    async ({ name }) => {
-      try {
-        return toolResult({ url: notes.getAttachmentUrl(name) });
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ name }) => wrapTool(() => ({ url: notes.getAttachmentUrl(name) })),
   );
 
   // ==========================================================================
@@ -286,14 +251,8 @@ export function createServer(options?: ServerOptions) {
           .describe("Maximum number of chats to return."),
       },
     },
-    async ({ search, sortBy, order, limit }) => {
-      try {
-        return toolResult(messages.chats({ search, sortBy, order, limit }));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ search, sortBy, order, limit }) =>
+      wrapTool(() => messages.chats({ search, sortBy, order, limit })),
   );
 
   server.registerTool(
@@ -308,14 +267,7 @@ export function createServer(options?: ServerOptions) {
           .describe("Numeric chat ID (from list_chats results)."),
       },
     },
-    async ({ chatId }) => {
-      try {
-        return toolResult(messages.getChat(chatId));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ chatId }) => wrapTool(() => messages.getChat(chatId)),
   );
 
   server.registerTool(
@@ -361,22 +313,16 @@ export function createServer(options?: ServerOptions) {
           .describe("Sort direction. Defaults to 'desc' (newest first)."),
       },
     },
-    async ({ chatId, limit, beforeDate, afterDate, fromMe, order }) => {
-      try {
-        return toolResult(
-          messages.messages(chatId, {
-            limit,
-            beforeDate: beforeDate ? new Date(beforeDate) : undefined,
-            afterDate: afterDate ? new Date(afterDate) : undefined,
-            fromMe,
-            order,
-          }),
-        );
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ chatId, limit, beforeDate, afterDate, fromMe, order }) =>
+      wrapTool(() =>
+        messages.messages(chatId, {
+          limit,
+          beforeDate: beforeDate ? new Date(beforeDate) : undefined,
+          afterDate: afterDate ? new Date(afterDate) : undefined,
+          fromMe,
+          order,
+        }),
+      ),
   );
 
   server.registerTool(
@@ -393,14 +339,7 @@ export function createServer(options?: ServerOptions) {
           ),
       },
     },
-    async ({ messageId }) => {
-      try {
-        return toolResult(messages.getMessage(messageId));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ messageId }) => wrapTool(() => messages.getMessage(messageId)),
   );
 
   server.registerTool(
@@ -424,14 +363,8 @@ export function createServer(options?: ServerOptions) {
           .describe("Maximum number of results to return. Defaults to 50."),
       },
     },
-    async ({ query, chatId, limit }) => {
-      try {
-        return toolResult(messages.search(query, { chatId, limit }));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ query, chatId, limit }) =>
+      wrapTool(() => messages.search(query, { chatId, limit })),
   );
 
   server.registerTool(
@@ -446,14 +379,7 @@ export function createServer(options?: ServerOptions) {
           .describe("Numeric message ID to get attachments for."),
       },
     },
-    async ({ messageId }) => {
-      try {
-        return toolResult(messages.attachments(messageId));
-      } catch (e) {
-        if (e instanceof MacOSError) return toolError(e.message);
-        throw e;
-      }
-    },
+    async ({ messageId }) => wrapTool(() => messages.attachments(messageId)),
   );
 
   return { server, notes, messages };

--- a/src/messages/database/connection.ts
+++ b/src/messages/database/connection.ts
@@ -1,31 +1,9 @@
-import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-  DatabaseAccessDeniedError,
-  DatabaseNotFoundError,
-} from "../../errors.ts";
+import { openDatabase as openDatabaseShared } from "../../database/connection.ts";
 
 const DEFAULT_DB_PATH = join(homedir(), "Library/Messages/chat.db");
 
-export function openDatabase(dbPath?: string): Database {
-  const path = dbPath ?? DEFAULT_DB_PATH;
-
-  if (!existsSync(path)) {
-    throw new DatabaseNotFoundError(path);
-  }
-
-  try {
-    return new Database(path, { readonly: true });
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "SQLITE_AUTH"
-    ) {
-      throw new DatabaseAccessDeniedError(path);
-    }
-    throw new DatabaseNotFoundError(path);
-  }
+export function openDatabase(dbPath?: string) {
+  return openDatabaseShared(dbPath, DEFAULT_DB_PATH);
 }

--- a/src/messages/database/queries.ts
+++ b/src/messages/database/queries.ts
@@ -1,16 +1,29 @@
-// Mac Absolute Time epoch: 2001-01-01 00:00:00 UTC
-// Offset from Unix epoch (1970-01-01) in seconds
-const MAC_EPOCH_OFFSET = 978307200;
+export { dateToMacNanos, macNanosToDate } from "../../database/timestamps.ts";
 
-// Messages timestamps are in nanoseconds since 2001-01-01
-export function macNanosToDate(nanos: number | null): Date {
-  if (nanos == null || nanos === 0) return new Date(0);
-  return new Date((nanos / 1e9 + MAC_EPOCH_OFFSET) * 1000);
-}
+const MESSAGE_COLUMNS = `
+    m.ROWID as id,
+    m.guid,
+    cmj.chat_id as chatId,
+    m.text,
+    m.attributedBody,
+    m.is_from_me as isFromMe,
+    m.handle_id as handleId,
+    m.date,
+    m.date_read as dateRead,
+    m.service,
+    m.is_audio_message as isAudioMessage,
+    m.cache_has_attachments as hasAttachments,
+    m.thread_originator_guid as threadOriginatorGuid,
+    m.reply_to_guid as replyToGuid`;
 
-export function dateToMacNanos(date: Date): number {
-  return (date.getTime() / 1000 - MAC_EPOCH_OFFSET) * 1e9;
-}
+const CHAT_COLUMNS = `
+    c.ROWID as id,
+    c.guid,
+    c.display_name as displayName,
+    c.chat_identifier as chatIdentifier,
+    c.style,
+    c.service_name as serviceName,
+    MAX(cmj.message_date) as lastMessageDate`;
 
 export const LIST_HANDLES = `
   SELECT
@@ -22,14 +35,7 @@ export const LIST_HANDLES = `
 `;
 
 export const LIST_CHATS = `
-  SELECT
-    c.ROWID as id,
-    c.guid,
-    c.display_name as displayName,
-    c.chat_identifier as chatIdentifier,
-    c.style,
-    c.service_name as serviceName,
-    MAX(cmj.message_date) as lastMessageDate
+  SELECT ${CHAT_COLUMNS}
   FROM chat c
   LEFT JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID
   GROUP BY c.ROWID
@@ -37,14 +43,7 @@ export const LIST_CHATS = `
 `;
 
 export const GET_CHAT = `
-  SELECT
-    c.ROWID as id,
-    c.guid,
-    c.display_name as displayName,
-    c.chat_identifier as chatIdentifier,
-    c.style,
-    c.service_name as serviceName,
-    MAX(cmj.message_date) as lastMessageDate
+  SELECT ${CHAT_COLUMNS}
   FROM chat c
   LEFT JOIN chat_message_join cmj ON cmj.chat_id = c.ROWID
   WHERE c.ROWID = ?
@@ -59,21 +58,7 @@ export const LIST_CHAT_PARTICIPANTS = `
 `;
 
 export const LIST_MESSAGES = `
-  SELECT
-    m.ROWID as id,
-    m.guid,
-    cmj.chat_id as chatId,
-    m.text,
-    m.attributedBody,
-    m.is_from_me as isFromMe,
-    m.handle_id as handleId,
-    m.date,
-    m.date_read as dateRead,
-    m.service,
-    m.is_audio_message as isAudioMessage,
-    m.cache_has_attachments as hasAttachments,
-    m.thread_originator_guid as threadOriginatorGuid,
-    m.reply_to_guid as replyToGuid
+  SELECT ${MESSAGE_COLUMNS}
   FROM message m
   JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
   WHERE cmj.chat_id = ?
@@ -81,42 +66,14 @@ export const LIST_MESSAGES = `
 `;
 
 export const GET_MESSAGE = `
-  SELECT
-    m.ROWID as id,
-    m.guid,
-    cmj.chat_id as chatId,
-    m.text,
-    m.attributedBody,
-    m.is_from_me as isFromMe,
-    m.handle_id as handleId,
-    m.date,
-    m.date_read as dateRead,
-    m.service,
-    m.is_audio_message as isAudioMessage,
-    m.cache_has_attachments as hasAttachments,
-    m.thread_originator_guid as threadOriginatorGuid,
-    m.reply_to_guid as replyToGuid
+  SELECT ${MESSAGE_COLUMNS}
   FROM message m
   LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
   WHERE m.ROWID = ?
 `;
 
 export const SEARCH_MESSAGES = `
-  SELECT
-    m.ROWID as id,
-    m.guid,
-    cmj.chat_id as chatId,
-    m.text,
-    m.attributedBody,
-    m.is_from_me as isFromMe,
-    m.handle_id as handleId,
-    m.date,
-    m.date_read as dateRead,
-    m.service,
-    m.is_audio_message as isAudioMessage,
-    m.cache_has_attachments as hasAttachments,
-    m.thread_originator_guid as threadOriginatorGuid,
-    m.reply_to_guid as replyToGuid
+  SELECT ${MESSAGE_COLUMNS}
   FROM message m
   LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
   WHERE m.text LIKE ?
@@ -125,21 +82,7 @@ export const SEARCH_MESSAGES = `
 `;
 
 export const SEARCH_MESSAGES_IN_CHAT = `
-  SELECT
-    m.ROWID as id,
-    m.guid,
-    cmj.chat_id as chatId,
-    m.text,
-    m.attributedBody,
-    m.is_from_me as isFromMe,
-    m.handle_id as handleId,
-    m.date,
-    m.date_read as dateRead,
-    m.service,
-    m.is_audio_message as isAudioMessage,
-    m.cache_has_attachments as hasAttachments,
-    m.thread_originator_guid as threadOriginatorGuid,
-    m.reply_to_guid as replyToGuid
+  SELECT ${MESSAGE_COLUMNS}
   FROM message m
   JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
   WHERE m.text LIKE ?

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import { openFullDiskAccessSettings } from "../errors.ts";
 import { openDatabase } from "./database/connection.ts";
 import { MessageReader } from "./database/reader.ts";
 import { ChatNotFoundError, MessageNotFoundError } from "./errors.ts";
@@ -64,9 +65,6 @@ export class Messages {
   }
 
   static requestAccess(): void {
-    Bun.spawn([
-      "open",
-      "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-    ]);
+    openFullDiskAccessSettings();
   }
 }

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -45,7 +45,10 @@ export interface MessageAttachment {
 }
 
 export type ChatSortField = "lastMessageDate" | "displayName";
-export type SortOrder = "asc" | "desc";
+
+import type { SortOrder } from "../types.ts";
+
+export type { SortOrder };
 
 export interface ListChatsOptions {
   search?: string;

--- a/src/notes/database/connection.ts
+++ b/src/notes/database/connection.ts
@@ -1,36 +1,14 @@
-import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import {
-  DatabaseAccessDeniedError,
-  DatabaseNotFoundError,
-} from "../../errors.ts";
+import { openDatabase as openDatabaseShared } from "../../database/connection.ts";
 
 const DEFAULT_DB_PATH = join(
   homedir(),
   "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite",
 );
 
-export function openDatabase(dbPath?: string): Database {
-  const path = dbPath ?? DEFAULT_DB_PATH;
-
-  if (!existsSync(path)) {
-    throw new DatabaseNotFoundError(path);
-  }
-
-  try {
-    return new Database(path, { readonly: true });
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "SQLITE_AUTH"
-    ) {
-      throw new DatabaseAccessDeniedError(path);
-    }
-    throw new DatabaseNotFoundError(path);
-  }
+export function openDatabase(dbPath?: string) {
+  return openDatabaseShared(dbPath, DEFAULT_DB_PATH);
 }
 
 export function defaultDatabasePath(): string {

--- a/src/notes/database/queries.ts
+++ b/src/notes/database/queries.ts
@@ -1,19 +1,12 @@
-// Mac Absolute Time epoch: 2001-01-01 00:00:00 UTC
-// Offset from Unix epoch (1970-01-01) in seconds
-export const MAC_EPOCH_OFFSET = 978307200;
+export {
+  dateToMacTime,
+  MAC_EPOCH_OFFSET,
+  macTimeToDate,
+} from "../../database/timestamps.ts";
 
 export interface DateColumns {
   createdAt: string;
   modifiedAt: string;
-}
-
-export function macTimeToDate(macTime: number | null): Date {
-  if (macTime == null) return new Date(0);
-  return new Date((macTime + MAC_EPOCH_OFFSET) * 1000);
-}
-
-export function dateToMacTime(date: Date): number {
-  return date.getTime() / 1000 - MAC_EPOCH_OFFSET;
 }
 
 // Entity types in ZICCLOUDSYNCINGOBJECT.Z_ENT

--- a/src/notes/notes.ts
+++ b/src/notes/notes.ts
@@ -1,4 +1,5 @@
 import type { Database } from "bun:sqlite";
+import { openFullDiskAccessSettings } from "../errors.ts";
 import { AttachmentResolver } from "./attachments/resolver.ts";
 import { noteToMarkdown } from "./conversion/proto-to-markdown.ts";
 import { openDatabase } from "./database/connection.ts";
@@ -142,9 +143,6 @@ export class Notes {
   }
 
   static requestAccess(): void {
-    Bun.spawn([
-      "open",
-      "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-    ]);
+    openFullDiskAccessSettings();
   }
 }

--- a/src/notes/types.ts
+++ b/src/notes/types.ts
@@ -52,7 +52,10 @@ export interface AttachmentRef {
 }
 
 export type NoteSortField = "title" | "createdAt" | "modifiedAt";
-export type SortOrder = "asc" | "desc";
+
+import type { SortOrder } from "../types.ts";
+
+export type { SortOrder };
 
 export interface SearchOptions {
   folder?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type SortOrder = "asc" | "desc";

--- a/tests/fixtures/create-messages-db.ts
+++ b/tests/fixtures/create-messages-db.ts
@@ -6,30 +6,17 @@
  */
 
 import { Database } from "bun:sqlite";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
+import {
+  FIXTURE_DIR,
+  cleanupDatabase,
+  dateToMacNanos as toMacNanos,
+} from "./helpers.ts";
 
-const FIXTURE_DIR = dirname(new URL(import.meta.url).pathname);
 const DB_PATH = resolve(FIXTURE_DIR, "chat.db");
 
-// Mac Absolute Time: nanoseconds since 2001-01-01 for Messages
-const MAC_EPOCH_OFFSET = 978307200;
-function toMacNanos(date: Date): number {
-  return (date.getTime() / 1000 - MAC_EPOCH_OFFSET) * 1e9;
-}
-
 // Delete existing DB
-try {
-  const { unlinkSync } = await import("node:fs");
-  try {
-    unlinkSync(DB_PATH);
-  } catch {}
-  try {
-    unlinkSync(`${DB_PATH}-wal`);
-  } catch {}
-  try {
-    unlinkSync(`${DB_PATH}-shm`);
-  } catch {}
-} catch {}
+cleanupDatabase(DB_PATH);
 
 const db = new Database(DB_PATH);
 

--- a/tests/fixtures/create-test-db.ts
+++ b/tests/fixtures/create-test-db.ts
@@ -7,19 +7,17 @@
 
 import { Database } from "bun:sqlite";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { gzipSync } from "node:zlib";
 import protobuf from "protobufjs";
+import {
+  FIXTURE_DIR,
+  cleanupDatabase,
+  dateToMacTime as toMacTime,
+} from "./helpers.ts";
 
-const FIXTURE_DIR = dirname(new URL(import.meta.url).pathname);
 const DB_PATH = resolve(FIXTURE_DIR, "NoteStore.sqlite");
-const PROTO_PATH = resolve(FIXTURE_DIR, "../../src/protobuf/notestore.proto");
-
-// Mac Absolute Time: seconds since 2001-01-01
-const MAC_EPOCH_OFFSET = 978307200;
-function toMacTime(date: Date): number {
-  return date.getTime() / 1000 - MAC_EPOCH_OFFSET;
-}
+const PROTO_PATH = resolve(FIXTURE_DIR, "../../src/notes/protobuf/notestore.proto");
 
 // Entity type IDs (Z_ENT values in Z_PRIMARYKEY)
 const ENT_ACCOUNT = 1;
@@ -192,19 +190,7 @@ function attachmentRun(
 // ============================================================================
 
 // Delete existing DB
-try {
-  Bun.file(DB_PATH).delete;
-  const { unlinkSync } = await import("node:fs");
-  try {
-    unlinkSync(DB_PATH);
-  } catch {}
-  try {
-    unlinkSync(`${DB_PATH}-wal`);
-  } catch {}
-  try {
-    unlinkSync(`${DB_PATH}-shm`);
-  } catch {}
-} catch {}
+cleanupDatabase(DB_PATH);
 
 const db = new Database(DB_PATH);
 

--- a/tests/fixtures/helpers.ts
+++ b/tests/fixtures/helpers.ts
@@ -1,0 +1,17 @@
+import { unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+
+export { dateToMacNanos, dateToMacTime } from "../../src/database/timestamps.ts";
+
+export const FIXTURE_DIR = dirname(new URL(import.meta.url).pathname);
+
+/**
+ * Remove an existing SQLite database and its WAL/SHM files.
+ */
+export function cleanupDatabase(dbPath: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${dbPath}${suffix}`);
+    } catch {}
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts duplicated infrastructure (database connection, timestamp conversion, error helpers, sort types) into shared modules under `src/database/` and `src/types.ts`
- Adds `wrapTool()` helper in MCP server to replace 13 identical try-catch blocks
- Deduplicates message/chat SQL column lists and fixture generator boilerplate into shared constants and `tests/fixtures/helpers.ts`
- Fixes pre-existing broken proto path in `create-test-db.ts`
- Net result: **-135 lines** (187 added, 322 removed) with no public API changes

## Test plan

- [x] `bun test` — all 163 tests pass
- [x] `bun run lint` — clean
- [x] Both fixture generators (`create-test-db.ts`, `create-messages-db.ts`) regenerate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)