### PR TITLE
Improve MCP tools with PATs framework patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,74 @@ macos-ts — TypeScript package for accessing macOS data (Notes, Photos, iMessag
 - 2 = Italic
 - 3 = Bold + Italic
 
+## MCP Tool Design Patterns (PATs Framework)
+
+Reference: [Patterns for Agentic Tools](https://arcade.dev/patterns/llm.txt)
+
+When adding or modifying MCP tools in `src/mcp-server.ts`, follow these patterns:
+
+### Tool Classification
+
+- **Query Tool**: Read-only, safe to retry, cacheable, parallelizable (all our tools are this type)
+- **Command Tool**: Has side effects; document irreversibility clearly
+- **Discovery Tool**: Reveals available operations, schema, capabilities
+
+### Tool Interface
+
+- **Descriptions**: Include prerequisites ("Requires a noteId from list_notes") and follow-ups ("Use read_note to get full content") directly in the description string
+- **Constrained Input**: Use enums, ranges, patterns via zod instead of free-form strings
+- **Smart Defaults**: Reduce required parameters with sensible defaults
+- **Natural Identifier**: Accept human-friendly identifiers (names, emails) and resolve internally, not just numeric IDs
+- **Parameter Coercion**: Accept flexible input formats (ISO dates, relative dates, string or number)
+
+### Tool Annotations
+
+Every tool should include MCP `annotations`:
+
+```typescript
+annotations: {
+  title: "Short human label",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+}
+```
+
+### Error Handling (Error-Guided Recovery)
+
+Errors should teach, not just fail. Every error response should include:
+
+- `error`: machine-readable error name
+- `message`: human-readable description
+- `category`: `"not_found" | "access_denied" | "password_protected" | "invalid_input" | "internal"`
+- `retryable`: boolean
+- `recovery`: specific actionable step (e.g., "Use list_notes to find valid note IDs")
+
+### Response Design
+
+- **Next Action Hints**: Include `_next` array suggesting follow-up tools with descriptions
+- **Token-Efficient**: Include `totalResults` count for list responses so agents don't need to count array items
+- **Progressive Detail**: Summary by default, full detail on request
+- **Response envelope**: `{ data, totalResults?, _next? }` — wraps raw data with metadata
+
+### Tool Discovery
+
+- Provide a `get_capabilities` tool that lists available data sources and their tools
+- Embed dependency hints ("call X before Y") in descriptions and error messages
+
+### Tool Composition
+
+- **Abstraction Ladder**: Provide both granular and higher-level operations
+- **Batch Operation**: Accept arrays for bulk reads, return per-item results
+- **Scatter-Gather**: Query parallel sources, merge results, handle partial failures
+
+### Security
+
+- **Secret Injection**: Credentials at runtime, never through LLM
+- **Permission Gate**: Enforce access control in code before execution
+- **Audit Trail**: Log tool invocations with identity, timestamp, duration
+
 ## Documentation
 
 When adding a new data source or changing the public API, update **both** `README.md` and `CLAUDE.md`. The README should include: a usage example for the TypeScript API, the MCP tools list, error types, and any new development commands.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 
 ### Available Tools
 
+#### Discovery
+
+- **get_capabilities** — Discover available data sources, their tools, and recommended starting points
+
 #### Notes
 
 - **list_accounts** — List all Apple Notes accounts on this Mac
@@ -121,12 +125,43 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 
 #### Messages
 
+- **list_handles** — List all known contact handles (phone numbers, email addresses)
 - **list_chats** — List iMessage/SMS conversations with optional search, sorting, and limiting
 - **get_chat** — Get details for a specific conversation by ID
 - **list_messages** — List messages in a conversation with date filtering and pagination
 - **get_message** — Get a single message by ID
 - **search_messages** — Search message text across all conversations or within a specific chat
 - **list_message_attachments** — List attachments for a specific message
+
+### Tool Response Format
+
+All tools return responses in a structured envelope:
+
+```json
+{
+  "data": [ ... ],
+  "totalResults": 42,
+  "_next": [
+    { "tool": "read_note", "description": "Read a note's full markdown content" }
+  ]
+}
+```
+
+- **data** — The actual result (array or object)
+- **totalResults** — Count of items (for array results)
+- **_next** — Suggested follow-up tools to call next
+
+Error responses include structured recovery guidance:
+
+```json
+{
+  "error": "NoteNotFoundError",
+  "message": "Note not found: 999",
+  "category": "not_found",
+  "retryable": false,
+  "recovery": "Use list_notes or search_notes to find valid note IDs."
+}
+```
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "bin": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,13 +1,37 @@
+export type ErrorCategory =
+  | "not_found"
+  | "access_denied"
+  | "invalid_input"
+  | "internal";
+
 export class MacOSError extends Error {
-  constructor(message: string, options?: { cause?: unknown }) {
+  readonly category: ErrorCategory;
+  readonly retryable: boolean;
+  readonly recovery: string;
+
+  constructor(
+    message: string,
+    options?: {
+      cause?: unknown;
+      category?: ErrorCategory;
+      retryable?: boolean;
+      recovery?: string;
+    },
+  ) {
     super(message, options);
     this.name = "MacOSError";
+    this.category = options?.category ?? "internal";
+    this.retryable = options?.retryable ?? false;
+    this.recovery = options?.recovery ?? "";
   }
 }
 
 export class DatabaseNotFoundError extends MacOSError {
   constructor(path: string) {
-    super(`Database not found or inaccessible: ${path}`);
+    super(`Database not found or inaccessible: ${path}`, {
+      category: "not_found",
+      recovery: `Ensure macOS Notes/Messages is set up on this Mac. Expected database at: ${path}`,
+    });
     this.name = "DatabaseNotFoundError";
   }
 }
@@ -19,6 +43,10 @@ export class DatabaseAccessDeniedError extends MacOSError {
     super(
       `Access denied to database: ${path}\n` +
         `Grant Full Disk Access${appHint} in System Settings → Privacy & Security → Full Disk Access.`,
+      {
+        category: "access_denied",
+        recovery: `Grant Full Disk Access${appHint} in System Settings > Privacy & Security > Full Disk Access, then restart the MCP server.`,
+      },
     );
     this.name = "DatabaseAccessDeniedError";
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7,27 +7,60 @@ import { MacOSError } from "./errors.ts";
 import { Messages, type MessagesOptions } from "./messages/index.ts";
 import { Notes, type NotesOptions } from "./notes/index.ts";
 
-function toolResult(data: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
-  };
+// ============================================================================
+// Response helpers
+// ============================================================================
+
+interface NextAction {
+  tool: string;
+  description: string;
 }
 
-function toolError(message: string) {
+const readOnlyAnnotations = {
+  readOnlyHint: true as const,
+  destructiveHint: false as const,
+  idempotentHint: true as const,
+  openWorldHint: false as const,
+};
+
+function toolError(e: MacOSError) {
   return {
     isError: true as const,
-    content: [{ type: "text" as const, text: message }],
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          error: e.name,
+          message: e.message,
+          category: e.category,
+          retryable: e.retryable,
+          recovery: e.recovery,
+        }),
+      },
+    ],
   };
 }
 
-function wrapTool<T>(fn: () => T) {
+function wrapTool<T>(fn: () => T, hints?: NextAction[]) {
   try {
-    return toolResult(fn());
+    const data = fn();
+    const result: Record<string, unknown> = { data };
+    if (Array.isArray(data)) result.totalResults = data.length;
+    if (hints?.length) result._next = hints;
+    return {
+      content: [
+        { type: "text" as const, text: JSON.stringify(result, null, 2) },
+      ],
+    };
   } catch (e) {
-    if (e instanceof MacOSError) return toolError(e.message);
+    if (e instanceof MacOSError) return toolError(e);
     throw e;
   }
 }
+
+// ============================================================================
+// Server
+// ============================================================================
 
 export interface ServerOptions {
   notes?: NotesOptions;
@@ -40,8 +73,58 @@ export function createServer(options?: ServerOptions) {
 
   const server = new McpServer({
     name: "macos",
-    version: "0.6.0",
+    version: "0.7.0",
   });
+
+  // ==========================================================================
+  // Discovery tool
+  // ==========================================================================
+
+  server.registerTool(
+    "get_capabilities",
+    {
+      title: "Get server capabilities",
+      description:
+        "Discover available data sources and their tools. Call this first to understand what macOS data this server can access and which tool to start with.",
+      annotations: readOnlyAnnotations,
+    },
+    async () =>
+      wrapTool(() => ({
+        dataSources: [
+          {
+            name: "Apple Notes",
+            description: "Read-only access to Apple Notes on this Mac",
+            tools: [
+              "list_accounts",
+              "list_folders",
+              "list_notes",
+              "search_notes",
+              "read_note",
+              "list_attachments",
+              "get_attachment_url",
+            ],
+            startWith: "list_accounts or list_notes",
+          },
+          {
+            name: "iMessage / SMS",
+            description:
+              "Read-only access to iMessage and SMS conversations on this Mac",
+            tools: [
+              "list_chats",
+              "get_chat",
+              "list_messages",
+              "get_message",
+              "search_messages",
+              "list_message_attachments",
+              "list_handles",
+            ],
+            startWith: "list_chats or search_messages",
+          },
+        ],
+        allToolsReadOnly: true,
+        requirement: "Full Disk Access permission for the terminal app",
+      })),
+  );
 
   // ==========================================================================
   // Notes tools
@@ -50,17 +133,28 @@ export function createServer(options?: ServerOptions) {
   server.registerTool(
     "list_accounts",
     {
+      title: "List Notes accounts",
       description:
-        "List all Apple Notes accounts configured on this Mac (e.g. iCloud, On My Mac). Returns each account's numeric ID and display name.",
+        "List all Apple Notes accounts on this Mac (e.g. iCloud, On My Mac). Returns account IDs and names. Use these to filter list_folders or list_notes.",
+      annotations: readOnlyAnnotations,
     },
-    async () => wrapTool(() => notes.accounts()),
+    async () =>
+      wrapTool(
+        () => notes.accounts(),
+        [
+          { tool: "list_folders", description: "List folders for an account" },
+          { tool: "list_notes", description: "List notes in an account" },
+        ],
+      ),
   );
 
   server.registerTool(
     "list_folders",
     {
+      title: "List Notes folders",
       description:
-        "List Apple Notes folders. Each folder includes its name, note count, and the account it belongs to. Optionally filter to a single account.",
+        "List Apple Notes folders with note counts. Optionally filter by account (from list_accounts). Use folder names/IDs to filter list_notes.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         account: z
           .string()
@@ -70,14 +164,20 @@ export function createServer(options?: ServerOptions) {
           ),
       },
     },
-    async ({ account }) => wrapTool(() => notes.folders(account)),
+    async ({ account }) =>
+      wrapTool(
+        () => notes.folders(account),
+        [{ tool: "list_notes", description: "List notes in a folder" }],
+      ),
   );
 
   server.registerTool(
     "list_notes",
     {
+      title: "List notes",
       description:
-        "List notes with optional filtering, sorting, and limiting. Returns metadata only (title, snippet, dates) — use read_note to get full content.",
+        "List notes with filtering, sorting, and limiting. Returns metadata only (title, snippet, dates). Use list_folders or list_accounts for filter values. Follow-up: use read_note with a noteId to get full markdown content.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         folder: z
           .string()
@@ -117,16 +217,24 @@ export function createServer(options?: ServerOptions) {
       },
     },
     async ({ folder, account, search, sortBy, order, limit }) =>
-      wrapTool(() =>
-        notes.notes({ folder, account, search, sortBy, order, limit }),
+      wrapTool(
+        () => notes.notes({ folder, account, search, sortBy, order, limit }),
+        [
+          {
+            tool: "read_note",
+            description: "Read a note's full markdown content",
+          },
+        ],
       ),
   );
 
   server.registerTool(
     "search_notes",
     {
+      title: "Search notes",
       description:
-        "Search Apple Notes by matching against note titles and text snippets. Returns metadata for matching notes — use read_note to get full content.",
+        "Search Apple Notes by text matching against titles and snippets. Returns metadata for matches. Follow-up: use read_note with a noteId for full content. Tip: use list_notes for browsing without a search term.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         query: z
           .string()
@@ -147,14 +255,19 @@ export function createServer(options?: ServerOptions) {
       },
     },
     async ({ query, folder, limit }) =>
-      wrapTool(() => notes.search(query, { folder, limit })),
+      wrapTool(
+        () => notes.search(query, { folder, limit }),
+        [{ tool: "read_note", description: "Read a matching note" }],
+      ),
   );
 
   server.registerTool(
     "read_note",
     {
+      title: "Read note content",
       description:
-        "Read the full content of an Apple Note as markdown. Supports pagination for large notes — pass offset and limit to read a specific range of lines.",
+        "Read the full content of an Apple Note as markdown. Requires a noteId from list_notes or search_notes. Supports pagination via offset/limit for large notes. Follow-up: use list_attachments to see attached files.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         noteId: z
           .number()
@@ -186,14 +299,21 @@ export function createServer(options?: ServerOptions) {
           return notes.read(noteId, { offset, limit });
         }
         return notes.read(noteId);
-      }),
+      }, [
+        {
+          tool: "list_attachments",
+          description: "See attachments for this note",
+        },
+      ]),
   );
 
   server.registerTool(
     "list_attachments",
     {
+      title: "List note attachments",
       description:
-        "List all attachments (images, files, etc.) for a specific note. Returns each attachment's name, content type, and local file URL if available.",
+        "List all attachments for a note. Requires a noteId from list_notes or search_notes. Follow-up: use get_attachment_url with a filename to get the local file path.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         noteId: z
           .number()
@@ -201,14 +321,25 @@ export function createServer(options?: ServerOptions) {
           .describe("Numeric note ID to get attachments for."),
       },
     },
-    async ({ noteId }) => wrapTool(() => notes.listAttachments(noteId)),
+    async ({ noteId }) =>
+      wrapTool(
+        () => notes.listAttachments(noteId),
+        [
+          {
+            tool: "get_attachment_url",
+            description: "Get file path for an attachment",
+          },
+        ],
+      ),
   );
 
   server.registerTool(
     "get_attachment_url",
     {
+      title: "Get attachment URL",
       description:
-        "Resolve a local file:// URL for a specific attachment by its filename. Returns null if the attachment file is not found on disk.",
+        "Resolve a local file:// URL for a note attachment by filename (from list_attachments). Returns null if file not found on disk.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         name: z
           .string()
@@ -223,10 +354,32 @@ export function createServer(options?: ServerOptions) {
   // ==========================================================================
 
   server.registerTool(
+    "list_handles",
+    {
+      title: "List message handles",
+      description:
+        "List all known contact handles (phone numbers, email addresses) from iMessage/SMS. Returns identifier (phone/email), service type (iMessage/SMS), and numeric ID. Useful for identifying senders in message results.",
+      annotations: readOnlyAnnotations,
+    },
+    async () =>
+      wrapTool(
+        () => messages.handles(),
+        [
+          {
+            tool: "list_chats",
+            description: "Find conversations with a contact",
+          },
+        ],
+      ),
+  );
+
+  server.registerTool(
     "list_chats",
     {
+      title: "List conversations",
       description:
-        "List iMessage/SMS conversations. Returns each chat's display name, participants, service type, and last message date. Optionally search by name or phone number.",
+        "List iMessage/SMS conversations with display names, participants, service type, and last message date. Supports search by name or phone number. Follow-up: use list_messages with a chatId to read the conversation.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         search: z
           .string()
@@ -252,14 +405,24 @@ export function createServer(options?: ServerOptions) {
       },
     },
     async ({ search, sortBy, order, limit }) =>
-      wrapTool(() => messages.chats({ search, sortBy, order, limit })),
+      wrapTool(
+        () => messages.chats({ search, sortBy, order, limit }),
+        [
+          {
+            tool: "list_messages",
+            description: "Read messages in a conversation",
+          },
+        ],
+      ),
   );
 
   server.registerTool(
     "get_chat",
     {
+      title: "Get conversation details",
       description:
-        "Get details for a specific iMessage/SMS conversation by its numeric ID, including all participants.",
+        "Get details for a specific conversation. Requires a chatId from list_chats. Returns participants and metadata. Follow-up: use list_messages to read messages.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         chatId: z
           .number()
@@ -267,14 +430,25 @@ export function createServer(options?: ServerOptions) {
           .describe("Numeric chat ID (from list_chats results)."),
       },
     },
-    async ({ chatId }) => wrapTool(() => messages.getChat(chatId)),
+    async ({ chatId }) =>
+      wrapTool(
+        () => messages.getChat(chatId),
+        [
+          {
+            tool: "list_messages",
+            description: "Read messages in this conversation",
+          },
+        ],
+      ),
   );
 
   server.registerTool(
     "list_messages",
     {
+      title: "List messages",
       description:
-        "List messages in a specific iMessage/SMS conversation. Supports date filtering and limiting. Returns message text, sender, date, and metadata.",
+        "List messages in a conversation. Requires a chatId from list_chats. Supports date filtering (ISO 8601), direction filtering (fromMe), and limiting. Follow-up: use get_message for details or list_message_attachments for media.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         chatId: z
           .number()
@@ -314,22 +488,32 @@ export function createServer(options?: ServerOptions) {
       },
     },
     async ({ chatId, limit, beforeDate, afterDate, fromMe, order }) =>
-      wrapTool(() =>
-        messages.messages(chatId, {
-          limit,
-          beforeDate: beforeDate ? new Date(beforeDate) : undefined,
-          afterDate: afterDate ? new Date(afterDate) : undefined,
-          fromMe,
-          order,
-        }),
+      wrapTool(
+        () =>
+          messages.messages(chatId, {
+            limit,
+            beforeDate: beforeDate ? new Date(beforeDate) : undefined,
+            afterDate: afterDate ? new Date(afterDate) : undefined,
+            fromMe,
+            order,
+          }),
+        [
+          { tool: "get_message", description: "Get full message details" },
+          {
+            tool: "list_message_attachments",
+            description: "Get attachments for a message",
+          },
+        ],
       ),
   );
 
   server.registerTool(
     "get_message",
     {
+      title: "Get message",
       description:
-        "Get a single iMessage/SMS message by its numeric ID. Returns the full message text, sender, date, and metadata.",
+        "Get a single message by ID (from list_messages or search_messages). Returns full text, sender, date, and metadata. Follow-up: use list_message_attachments for attached media.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         messageId: z
           .number()
@@ -339,14 +523,25 @@ export function createServer(options?: ServerOptions) {
           ),
       },
     },
-    async ({ messageId }) => wrapTool(() => messages.getMessage(messageId)),
+    async ({ messageId }) =>
+      wrapTool(
+        () => messages.getMessage(messageId),
+        [
+          {
+            tool: "list_message_attachments",
+            description: "Get attachments for this message",
+          },
+        ],
+      ),
   );
 
   server.registerTool(
     "search_messages",
     {
+      title: "Search messages",
       description:
-        "Search iMessage/SMS message text across all conversations or within a specific chat. Returns matching messages with sender, date, and chat context.",
+        "Search message text across all conversations or within a specific chat (chatId from list_chats). Follow-up: use get_message or list_message_attachments with a messageId.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         query: z.string().describe("Text to search for in message content."),
         chatId: z
@@ -364,14 +559,19 @@ export function createServer(options?: ServerOptions) {
       },
     },
     async ({ query, chatId, limit }) =>
-      wrapTool(() => messages.search(query, { chatId, limit })),
+      wrapTool(
+        () => messages.search(query, { chatId, limit }),
+        [{ tool: "get_message", description: "Get full message details" }],
+      ),
   );
 
   server.registerTool(
     "list_message_attachments",
     {
+      title: "List message attachments",
       description:
-        "List all attachments (images, files, etc.) for a specific iMessage/SMS message. Returns filename, MIME type, and file size.",
+        "List attachments for a message. Requires a messageId from list_messages or search_messages. Returns filename, MIME type, and file size.",
+      annotations: readOnlyAnnotations,
       inputSchema: {
         messageId: z
           .number()

--- a/src/messages/errors.ts
+++ b/src/messages/errors.ts
@@ -2,14 +2,21 @@ import { MacOSError } from "../errors.ts";
 
 export class ChatNotFoundError extends MacOSError {
   constructor(chatId: number) {
-    super(`Chat not found: ${chatId}`);
+    super(`Chat not found: ${chatId}`, {
+      category: "not_found",
+      recovery: "Use list_chats to find valid chat IDs.",
+    });
     this.name = "ChatNotFoundError";
   }
 }
 
 export class MessageNotFoundError extends MacOSError {
   constructor(messageId: number) {
-    super(`Message not found: ${messageId}`);
+    super(`Message not found: ${messageId}`, {
+      category: "not_found",
+      recovery:
+        "Use list_messages or search_messages to find valid message IDs.",
+    });
     this.name = "MessageNotFoundError";
   }
 }

--- a/src/notes/errors.ts
+++ b/src/notes/errors.ts
@@ -2,14 +2,21 @@ import { MacOSError } from "../errors.ts";
 
 export class NoteNotFoundError extends MacOSError {
   constructor(noteId: number) {
-    super(`Note not found: ${noteId}`);
+    super(`Note not found: ${noteId}`, {
+      category: "not_found",
+      recovery: "Use list_notes or search_notes to find valid note IDs.",
+    });
     this.name = "NoteNotFoundError";
   }
 }
 
 export class PasswordProtectedError extends MacOSError {
   constructor(noteId: number) {
-    super(`Note is password protected and cannot be read: ${noteId}`);
+    super(`Note is password protected and cannot be read: ${noteId}`, {
+      category: "access_denied",
+      recovery:
+        "This note is password-protected and cannot be read via the database.",
+    });
     this.name = "PasswordProtectedError";
   }
 }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -41,13 +41,18 @@ afterAll(async () => {
 // ============================================================================
 
 // biome-ignore lint/suspicious/noExplicitAny: test helper
-function parseResult(result: any) {
+function parseRaw(result: any) {
   return JSON.parse(result.content[0].text);
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: test helper
-function getErrorText(result: any): string {
-  return result.content[0].text;
+function parseResult(result: any) {
+  return parseRaw(result).data;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+function getErrorJson(result: any) {
+  return JSON.parse(result.content[0].text);
 }
 
 // ============================================================================
@@ -55,9 +60,9 @@ function getErrorText(result: any): string {
 // ============================================================================
 
 describe("server metadata", () => {
-  test("server exposes 13 tools", async () => {
+  test("server exposes 15 tools", async () => {
     const { tools } = await client.listTools();
-    expect(tools).toHaveLength(13);
+    expect(tools).toHaveLength(15);
   });
 
   test("each tool has a description", async () => {
@@ -73,12 +78,14 @@ describe("server metadata", () => {
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "get_attachment_url",
+      "get_capabilities",
       "get_chat",
       "get_message",
       "list_accounts",
       "list_attachments",
       "list_chats",
       "list_folders",
+      "list_handles",
       "list_message_attachments",
       "list_messages",
       "list_notes",
@@ -98,6 +105,74 @@ describe("server metadata", () => {
     expect(props.query?.description).toBeTruthy();
     expect(props.folder?.description).toBeTruthy();
     expect(props.limit?.description).toBeTruthy();
+  });
+
+  test("all tools have readOnlyHint annotation", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      // biome-ignore lint/suspicious/noExplicitAny: test
+      const annotations = (tool as any).annotations;
+      if (annotations) {
+        expect(annotations.readOnlyHint).toBe(true);
+        expect(annotations.destructiveHint).toBe(false);
+      }
+    }
+  });
+});
+
+// ============================================================================
+// get_capabilities
+// ============================================================================
+
+describe("get_capabilities", () => {
+  test("returns data sources with tool lists", async () => {
+    const result = await client.callTool({ name: "get_capabilities" });
+    const data = parseResult(result);
+    expect(data.dataSources).toHaveLength(2);
+    expect(data.dataSources[0].name).toBe("Apple Notes");
+    expect(data.dataSources[1].name).toBe("iMessage / SMS");
+    expect(data.allToolsReadOnly).toBe(true);
+    expect(data.requirement).toContain("Full Disk Access");
+  });
+
+  test("each data source lists its tools and starting point", async () => {
+    const result = await client.callTool({ name: "get_capabilities" });
+    const data = parseResult(result);
+    for (const source of data.dataSources) {
+      expect(source.tools.length).toBeGreaterThan(0);
+      expect(source.startWith).toBeTruthy();
+    }
+  });
+});
+
+// ============================================================================
+// response envelope
+// ============================================================================
+
+describe("response envelope", () => {
+  test("list tools include totalResults count", async () => {
+    const result = await client.callTool({ name: "list_accounts" });
+    const raw = parseRaw(result);
+    expect(typeof raw.totalResults).toBe("number");
+    expect(raw.totalResults).toBe(raw.data.length);
+  });
+
+  test("list tools include _next hints", async () => {
+    const result = await client.callTool({ name: "list_accounts" });
+    const raw = parseRaw(result);
+    expect(raw._next).toBeDefined();
+    expect(raw._next.length).toBeGreaterThan(0);
+    expect(raw._next[0].tool).toBeTruthy();
+    expect(raw._next[0].description).toBeTruthy();
+  });
+
+  test("terminal tools omit _next hints", async () => {
+    const result = await client.callTool({
+      name: "get_attachment_url",
+      arguments: { name: "nonexistent.png" },
+    });
+    const raw = parseRaw(result);
+    expect(raw._next).toBeUndefined();
   });
 });
 
@@ -306,16 +381,20 @@ describe("read_note", () => {
     expect(typeof page.hasMore).toBe("boolean");
   });
 
-  test("returns error for nonexistent note ID", async () => {
+  test("returns structured error for nonexistent note ID", async () => {
     const result = await client.callTool({
       name: "read_note",
       arguments: { noteId: 999999 },
     });
     expect(result.isError).toBe(true);
-    expect(getErrorText(result)).toContain("Note not found");
+    const err = getErrorJson(result);
+    expect(err.error).toBe("NoteNotFoundError");
+    expect(err.category).toBe("not_found");
+    expect(err.retryable).toBe(false);
+    expect(err.recovery).toContain("list_notes");
   });
 
-  test("returns error for password-protected note", async () => {
+  test("returns structured error for password-protected note", async () => {
     const listResult = await client.callTool({
       name: "list_notes",
       arguments: {},
@@ -331,7 +410,11 @@ describe("read_note", () => {
       arguments: { noteId: locked.id },
     });
     expect(result.isError).toBe(true);
-    expect(getErrorText(result)).toContain("password protected");
+    const err = getErrorJson(result);
+    expect(err.error).toBe("PasswordProtectedError");
+    expect(err.category).toBe("access_denied");
+    expect(err.retryable).toBe(false);
+    expect(err.recovery).toContain("password-protected");
   });
 });
 
@@ -367,6 +450,21 @@ describe("get_attachment_url", () => {
     });
     const data = parseResult(result);
     expect(data.url).toBeNull();
+  });
+});
+
+// ============================================================================
+// list_handles
+// ============================================================================
+
+describe("list_handles", () => {
+  test("returns handles from fixture DB", async () => {
+    const result = await client.callTool({ name: "list_handles" });
+    const handles = parseResult(result);
+    expect(Array.isArray(handles)).toBe(true);
+    expect(handles.length).toBeGreaterThan(0);
+    expect(handles[0].identifier).toBeTruthy();
+    expect(handles[0].service).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

- **Structured error responses**: All errors now return JSON with `error`, `message`, `category`, `retryable`, and `recovery` fields so LLM agents can classify failures and know how to recover
- **Tool annotations**: All 15 tools marked with `readOnlyHint`, `idempotentHint`, `destructiveHint`, `openWorldHint` MCP annotations
- **Enhanced descriptions**: Every tool description includes prerequisite and follow-up hints (e.g., "Requires a noteId from list_notes", "Follow-up: use read_note")
- **Response envelope**: All responses wrapped in `{ data, totalResults, _next }` with item counts and next-action suggestions
- **New tools**: `get_capabilities` (discovery/orientation) and `list_handles` (contact lookup from Messages)
- **Docs**: PATs framework reference added to CLAUDE.md, new tools and response format documented in README
- **Version bump**: 0.6.2 → 0.7.0

## Test plan

- [x] All 170 tests pass (`bun test`)
- [x] Lint + type check clean (`bun run lint`)
- [ ] Manual: run `bun run mcp` and call `get_capabilities`, verify structured response
- [ ] Manual: call `read_note` with invalid ID, verify structured error with recovery guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)