### PR TITLE
Add photo viewer to TUI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "bin": {

--- a/tui/helpers.ts
+++ b/tui/helpers.ts
@@ -297,6 +297,9 @@ export function handleScrollKeys(
  */
 export function buildFooter(tab: Tab): string {
   const base = `${term.dim}1/2/3/4${term.reset} tabs  ${term.dim}\u2190\u2192${term.reset} panels  ${term.dim}\u2191\u2193${term.reset} navigate  ${term.dim}j/k${term.reset} scroll`;
-  const open = tab === "notes" ? `  ${term.dim}o${term.reset} open` : "";
+  const open =
+    tab === "notes" || tab === "photos"
+      ? `  ${term.dim}o${term.reset} open`
+      : "";
   return ` ${base}${open}  ${term.dim}/${term.reset} search  ${term.dim}q${term.reset} quit`;
 }

--- a/tui/photos.ts
+++ b/tui/photos.ts
@@ -3,6 +3,7 @@ import {
   type AppState,
   bodyRows,
   highlightLine,
+  hyperlink,
   moveTo,
   photoAlbumPanelWidth,
   photoDetailPanelWidth,
@@ -90,6 +91,10 @@ function loadSelectedPhoto(state: AppState, photosDb: Photos) {
       const sec = Math.floor(details.duration % 60);
       lines.push(`  Duration: ${min}:${sec.toString().padStart(2, "0")}`);
     }
+    const photoUrl = photosDb.getPhotoUrl(photo.id);
+    const filePath = photoUrl.url.replace("file://", "");
+    const displayPath = truncate(filePath, w - 8);
+    lines.push(`  Path: ${hyperlink(photoUrl.url, displayPath)}`);
     lines.push("");
 
     // Flags
@@ -287,6 +292,28 @@ export function handlePhotosInput(
     case "K":
       ps.detailScroll = Math.max(0, ps.detailScroll - bodyRows());
       break;
+    case "\r":
+    case "o": {
+      const photo = ps.photos[ps.photoIndex];
+      if (!photo) {
+        state.statusMessage = "No photo selected";
+        break;
+      }
+      try {
+        const photoUrl = photosDb.getPhotoUrl(photo.id);
+        if (!photoUrl.locallyAvailable) {
+          state.statusMessage =
+            "Photo is in iCloud only — not available locally";
+          break;
+        }
+        const filePath = photoUrl.url.replace("file://", "");
+        Bun.spawn(["open", filePath]);
+        state.statusMessage = `Opened: ${photo.filename}`;
+      } catch {
+        state.statusMessage = "Could not open photo";
+      }
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Press Enter or `o` on a selected photo in the Photos TUI tab to open it in macOS Preview via the system `open` command
- Shows the resolved file path as a clickable terminal hyperlink (OSC 8) in the detail panel
- Handles iCloud-only photos gracefully with a status message instead of failing
- Adds "o open" hint to the footer bar on the Photos tab

## Test plan
- [ ] `bun run lint` passes
- [ ] `bun test` passes (250 tests)
- [ ] `bun tui` → Photos tab → select a local photo → press Enter or `o` → opens in Preview
- [ ] Select an iCloud-only photo → press `o` → shows "Photo is in iCloud only" status message
- [ ] Verify file path displays as clickable hyperlink in detail panel (iTerm2/Warp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)