### PR TITLE
Fix Notes attachment FK + add attachmentLinkBuilder API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/src/notes/attachments/resolver.ts
+++ b/src/notes/attachments/resolver.ts
@@ -7,6 +7,10 @@ const DEFAULT_CONTAINER_PATH = join(
   "Library/Group Containers/group.com.apple.notes",
 );
 
+export type ResolveResult =
+  | { path: string }
+  | { error: "not-found" | "permission-denied" };
+
 export class AttachmentResolver {
   private containerPath: string;
 
@@ -14,7 +18,16 @@ export class AttachmentResolver {
     this.containerPath = containerPath ?? DEFAULT_CONTAINER_PATH;
   }
 
+  // Back-compat: returns the file URL or null. Callers that need to
+  // distinguish "not found" from "permission denied" should use resolveDetailed.
   resolve(identifier: string): string | null {
+    const result = this.resolveDetailed(identifier);
+    return "path" in result ? `file://${result.path}` : null;
+  }
+
+  resolveDetailed(identifier: string): ResolveResult {
+    let sawPermissionError = false;
+
     // Search in priority order: FallbackPDFs first (for scanned/Paper docs),
     // then Media (most common), then the full Accounts tree as fallback.
     const accountsPath = join(this.containerPath, "Accounts");
@@ -24,16 +37,16 @@ export class AttachmentResolver {
         for (const acct of accounts) {
           if (!acct.isDirectory()) continue;
           const acctPath = join(accountsPath, acct.name);
-          // Prioritized subdirectories within each account
           for (const sub of ["FallbackPDFs", "Media"]) {
             const subPath = join(acctPath, sub);
             if (!existsSync(subPath)) continue;
             const found = this.findFile(subPath, identifier);
-            if (found) return `file://${found}`;
+            if (found.path) return { path: found.path };
+            if (found.permissionDenied) sawPermissionError = true;
           }
         }
-      } catch {
-        // Permission denied
+      } catch (err) {
+        if (isPermissionError(err)) sawPermissionError = true;
       }
     }
 
@@ -42,35 +55,46 @@ export class AttachmentResolver {
       const basePath = join(this.containerPath, sub);
       if (!existsSync(basePath)) continue;
       const found = this.findFile(basePath, identifier);
-      if (found) return `file://${found}`;
+      if (found.path) return { path: found.path };
+      if (found.permissionDenied) sawPermissionError = true;
     }
 
-    return null;
+    return { error: sawPermissionError ? "permission-denied" : "not-found" };
   }
 
-  private findFirstFile(dir: string, depth = 0): string | null {
-    if (depth > 2) return null;
+  private findFirstFile(
+    dir: string,
+    depth = 0,
+  ): { path: string | null; permissionDenied: boolean } {
+    if (depth > 2) return { path: null, permissionDenied: false };
+    let permissionDenied = false;
     try {
       const entries = readdirSync(dir, { withFileTypes: true });
       // Prefer files at current level
       const file = entries.find((e) => e.isFile());
-      if (file) return join(dir, file.name);
+      if (file) return { path: join(dir, file.name), permissionDenied: false };
       // Otherwise recurse into subdirectories
       for (const entry of entries) {
         if (entry.isDirectory()) {
           const found = this.findFirstFile(join(dir, entry.name), depth + 1);
-          if (found) return found;
+          if (found.path) return found;
+          if (found.permissionDenied) permissionDenied = true;
         }
       }
-    } catch {
-      // Permission denied or other FS error
+    } catch (err) {
+      if (isPermissionError(err)) permissionDenied = true;
     }
-    return null;
+    return { path: null, permissionDenied };
   }
 
-  private findFile(dir: string, identifier: string, depth = 0): string | null {
+  private findFile(
+    dir: string,
+    identifier: string,
+    depth = 0,
+  ): { path: string | null; permissionDenied: boolean } {
     const MAX_DEPTH = 4;
-    if (depth > MAX_DEPTH) return null;
+    if (depth > MAX_DEPTH) return { path: null, permissionDenied: false };
+    let permissionDenied = false;
     try {
       const entries = readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
@@ -82,16 +106,23 @@ export class AttachmentResolver {
           if (entry.name === identifier) {
             // Found the UUID directory — find the first file in it (may be nested)
             const file = this.findFirstFile(fullPath);
-            if (file) return file;
+            if (file.path) return file;
+            if (file.permissionDenied) permissionDenied = true;
           }
           // Recurse deeper (e.g. Accounts/<acct>/Media/<uuid>/file)
           const found = this.findFile(fullPath, identifier, depth + 1);
-          if (found) return found;
+          if (found.path) return found;
+          if (found.permissionDenied) permissionDenied = true;
         }
       }
-    } catch {
-      // Permission denied or other FS error
+    } catch (err) {
+      if (isPermissionError(err)) permissionDenied = true;
     }
-    return null;
+    return { path: null, permissionDenied };
   }
+}
+
+function isPermissionError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  return code === "EACCES" || code === "EPERM";
 }

--- a/src/notes/conversion/proto-to-markdown.ts
+++ b/src/notes/conversion/proto-to-markdown.ts
@@ -3,6 +3,11 @@ import type {
   DecodedNote,
   DecodedTable,
 } from "../protobuf/decode.ts";
+import type {
+  AttachmentLinkInfo,
+  AttachmentRef,
+  ReadOptions,
+} from "../types.ts";
 
 // ParagraphStyle.style_type values (from notestore.proto)
 const STYLE_TITLE = 0;
@@ -22,6 +27,8 @@ const FONT_WEIGHT_BOLD_ITALIC = 3;
 export function noteToMarkdown(
   note: DecodedNote,
   tables?: Map<string, DecodedTable>,
+  attachments?: AttachmentRef[],
+  options?: ReadOptions,
 ): string {
   if (!note.text) return "";
 
@@ -29,6 +36,19 @@ export function noteToMarkdown(
   const lines = splitIntoLines(text, attributeRuns);
   const mdLines: string[] = [];
   let inCodeBlock = false;
+
+  // Build identifier → AttachmentLinkInfo lookup for the link builder.
+  const linkInfo = new Map<string, AttachmentLinkInfo>();
+  if (attachments) {
+    for (const a of attachments) {
+      if (!a.identifier) continue;
+      linkInfo.set(a.identifier, {
+        identifier: a.identifier,
+        name: a.name,
+        contentType: a.contentType,
+      });
+    }
+  }
 
   for (const line of lines) {
     const isCode = line.paragraphStyle?.styleType === STYLE_MONOSPACED;
@@ -49,7 +69,7 @@ export function noteToMarkdown(
       if (tableMarkdown != null) {
         mdLines.push(tableMarkdown);
       } else {
-        mdLines.push(renderLine(line));
+        mdLines.push(renderLine(line, linkInfo, options));
       }
     }
   }
@@ -136,12 +156,21 @@ function splitIntoLines(
   return lines;
 }
 
-function renderLine(line: LineParts): string {
+function renderLine(
+  line: LineParts,
+  linkInfo: Map<string, AttachmentLinkInfo>,
+  options?: ReadOptions,
+): string {
   const style = line.paragraphStyle;
   const styleType = style?.styleType;
   const indent = style?.indentAmount ?? 0;
   const indentStr = "  ".repeat(indent);
-  const inlineText = renderInlineFormatting(line.text, line.runs);
+  const inlineText = renderInlineFormatting(
+    line.text,
+    line.runs,
+    linkInfo,
+    options,
+  );
 
   // Title (first line of note) → # heading
   if (styleType === STYLE_TITLE) {
@@ -185,6 +214,8 @@ function renderLine(line: LineParts): string {
 function renderInlineFormatting(
   text: string,
   runs: DecodedAttributeRun[],
+  linkInfo: Map<string, AttachmentLinkInfo>,
+  options?: ReadOptions,
 ): string {
   if (runs.length === 0) return text;
 
@@ -201,7 +232,15 @@ function renderInlineFormatting(
     if (run.attachmentInfo?.attachmentIdentifier) {
       const id = run.attachmentInfo.attachmentIdentifier;
       const uti = run.attachmentInfo.typeUti ?? "unknown";
-      result += `![attachment](attachment:${id}?type=${uti})`;
+      const builder = options?.attachmentLinkBuilder;
+      const info = linkInfo.get(id);
+      if (builder && info) {
+        const url = builder(info);
+        const label = info.name || "attachment";
+        result += `![${label}](${url})`;
+      } else {
+        result += `![attachment](attachment:${id}?type=${uti})`;
+      }
       continue;
     }
 

--- a/src/notes/database/queries.ts
+++ b/src/notes/database/queries.ts
@@ -9,6 +9,11 @@ export interface DateColumns {
   modifiedAt: string;
 }
 
+export interface AttachmentColumns {
+  // FK from attachment row → note row. Older schemas use ZNOTE1, newer ZNOTE.
+  noteFk: string;
+}
+
 // Entity types in ZICCLOUDSYNCINGOBJECT.Z_ENT
 // These vary by macOS version. We discover them at runtime.
 
@@ -114,15 +119,16 @@ export const searchBySnippet = (dateCols: DateColumns) => `
   LIMIT ?
 `;
 
-export const GET_ATTACHMENTS = `
+export const getAttachments = (cols: AttachmentColumns) => `
   SELECT
     a.Z_PK as id,
     a.ZIDENTIFIER as identifier,
-    a.ZFILENAME as name,
+    COALESCE(NULLIF(a.ZFILENAME, ''), m.ZFILENAME) as name,
     a.ZTYPEUTI as contentType,
-    a.ZNOTE1 as noteId
+    a.${cols.noteFk} as noteId
   FROM ZICCLOUDSYNCINGOBJECT a
-  WHERE a.ZNOTE1 = ?
+  LEFT JOIN ZICCLOUDSYNCINGOBJECT m ON m.Z_PK = a.ZMEDIA
+  WHERE a.${cols.noteFk} = ?
     AND a.ZTYPEUTI IS NOT NULL
     AND a.Z_ENT = ?
 `;

--- a/src/notes/database/reader.ts
+++ b/src/notes/database/reader.ts
@@ -7,7 +7,7 @@ import type {
   NoteMeta,
   SearchOptions,
 } from "../types.ts";
-import type { DateColumns } from "./queries.ts";
+import type { AttachmentColumns, DateColumns } from "./queries.ts";
 import * as Q from "./queries.ts";
 
 interface EntityTypes {
@@ -61,6 +61,7 @@ export class NoteReader {
   private db: Database;
   private entityTypes: EntityTypes;
   private dateColumns: DateColumns;
+  private attachmentColumns: AttachmentColumns;
   private folderCache: Map<number, { name: string; accountId: number }> =
     new Map();
   private accountCache: Map<number, string> = new Map();
@@ -69,6 +70,7 @@ export class NoteReader {
     this.db = db;
     this.entityTypes = this.discoverEntityTypes();
     this.dateColumns = this.discoverDateColumns();
+    this.attachmentColumns = this.discoverAttachmentColumns();
     this.buildCaches();
   }
 
@@ -137,6 +139,28 @@ export class NoteReader {
     }
 
     return candidates[0] ?? null;
+  }
+
+  private discoverAttachmentColumns(): AttachmentColumns {
+    // The attachment→note FK column varies by macOS version: older schemas
+    // use ZNOTE1, newer use ZNOTE. Pick whichever has non-NULL data on
+    // attachment rows; fall back to ZNOTE1 for back-compat with test fixtures.
+    const rows = this.db
+      .query("PRAGMA table_info(ZICCLOUDSYNCINGOBJECT)")
+      .all() as ColumnInfoRow[];
+    const columns = rows.map((r) => r.name);
+    const candidates = ["ZNOTE", "ZNOTE1"].filter((c) => columns.includes(c));
+
+    for (const col of candidates) {
+      const row = this.db
+        .query(
+          `SELECT ${col} as v FROM ZICCLOUDSYNCINGOBJECT WHERE ${col} IS NOT NULL AND Z_ENT = ? LIMIT 1`,
+        )
+        .get(this.entityTypes.attachment) as { v: number } | null;
+      if (row) return { noteFk: col };
+    }
+
+    return { noteFk: candidates[0] ?? "ZNOTE1" };
   }
 
   private buildCaches(): void {
@@ -349,7 +373,7 @@ export class NoteReader {
 
   listAttachments(noteId: number): AttachmentRef[] {
     const rows = this.db
-      .query(Q.GET_ATTACHMENTS)
+      .query(Q.getAttachments(this.attachmentColumns))
       .all(noteId, this.entityTypes.attachment) as AttachmentRow[];
 
     return rows.map((r) => ({

--- a/src/notes/index.ts
+++ b/src/notes/index.ts
@@ -1,3 +1,4 @@
+export type { ResolveResult } from "./attachments/resolver.ts";
 export { NoteNotFoundError, PasswordProtectedError } from "./errors.ts";
 export type { NotesOptions } from "./notes.ts";
 export { Notes } from "./notes.ts";
@@ -5,6 +6,7 @@ export type {
   Account,
   AccountId,
   AttachmentId,
+  AttachmentLinkInfo,
   AttachmentRef,
   Folder,
   FolderId,
@@ -15,6 +17,7 @@ export type {
   NoteMeta,
   NoteSortField,
   PaginationOptions,
+  ReadOptions,
   SearchOptions,
   SortOrder,
 } from "./types.ts";

--- a/src/notes/notes.ts
+++ b/src/notes/notes.ts
@@ -1,6 +1,9 @@
 import type { Database } from "bun:sqlite";
 import { openFullDiskAccessSettings } from "../errors.ts";
-import { AttachmentResolver } from "./attachments/resolver.ts";
+import {
+  AttachmentResolver,
+  type ResolveResult,
+} from "./attachments/resolver.ts";
 import { noteToMarkdown } from "./conversion/proto-to-markdown.ts";
 import { openDatabase } from "./database/connection.ts";
 import { NoteReader } from "./database/reader.ts";
@@ -19,6 +22,7 @@ import type {
   NoteContentPage,
   NoteMeta,
   PaginationOptions,
+  ReadOptions,
   SearchOptions,
 } from "./types.ts";
 
@@ -42,12 +46,30 @@ export class Notes {
     return this.reader.search(query, options);
   }
 
-  read(noteId: number): NoteContent;
-  read(noteId: number, pagination: PaginationOptions): NoteContentPage;
+  read(noteId: number, options?: ReadOptions): NoteContent;
   read(
     noteId: number,
-    pagination?: PaginationOptions,
+    pagination: PaginationOptions,
+    options?: ReadOptions,
+  ): NoteContentPage;
+  read(
+    noteId: number,
+    paginationOrOptions?: PaginationOptions | ReadOptions,
+    maybeOptions?: ReadOptions,
   ): NoteContent | NoteContentPage {
+    // Disambiguate: a PaginationOptions has offset|limit; a ReadOptions has
+    // attachmentLinkBuilder. The single-arg form may be either.
+    let pagination: PaginationOptions | undefined;
+    let options: ReadOptions | undefined;
+    if (paginationOrOptions) {
+      if ("offset" in paginationOrOptions || "limit" in paginationOrOptions) {
+        pagination = paginationOrOptions as PaginationOptions;
+        options = maybeOptions;
+      } else {
+        options = paginationOrOptions as ReadOptions;
+      }
+    }
+
     const result = this.reader.getNote(noteId);
     if (!result) throw new NoteNotFoundError(noteId);
 
@@ -61,7 +83,10 @@ export class Notes {
     if (zdata) {
       const decoded = decodeNoteData(zdata);
       const tables = this.resolveTableAttachments(decoded);
-      markdown = noteToMarkdown(decoded, tables);
+      const attachments = options?.attachmentLinkBuilder
+        ? this.listAttachments(noteId)
+        : undefined;
+      markdown = noteToMarkdown(decoded, tables, attachments, options);
     }
 
     if (pagination) {
@@ -114,6 +139,18 @@ export class Notes {
 
     // Fall back to resolving directly by the attachment identifier
     return this.attachmentResolver.resolve(attachmentId);
+  }
+
+  // Like getAttachmentUrl, but returns a structured result so callers can
+  // distinguish "not-found" from "permission-denied". Returns the absolute
+  // file path on success (no file:// prefix).
+  resolveAttachment(attachmentId: string): ResolveResult {
+    const media = this.reader.resolveMediaIdentifier(attachmentId);
+    if (media) {
+      const r = this.attachmentResolver.resolveDetailed(media.mediaIdentifier);
+      if ("path" in r) return r;
+    }
+    return this.attachmentResolver.resolveDetailed(attachmentId);
   }
 
   private resolveTableAttachments(

--- a/src/notes/notes.ts
+++ b/src/notes/notes.ts
@@ -146,11 +146,24 @@ export class Notes {
   // file path on success (no file:// prefix).
   resolveAttachment(attachmentId: string): ResolveResult {
     const media = this.reader.resolveMediaIdentifier(attachmentId);
+    let firstError: ResolveResult | undefined;
     if (media) {
       const r = this.attachmentResolver.resolveDetailed(media.mediaIdentifier);
       if ("path" in r) return r;
+      firstError = r;
     }
-    return this.attachmentResolver.resolveDetailed(attachmentId);
+    const second = this.attachmentResolver.resolveDetailed(attachmentId);
+    if ("path" in second) return second;
+    // Prefer permission-denied over not-found so an access problem on the
+    // media path isn't masked by a not-found on the attachment-id fallback.
+    if (
+      firstError &&
+      "error" in firstError &&
+      firstError.error === "permission-denied"
+    ) {
+      return firstError;
+    }
+    return second;
   }
 
   private resolveTableAttachments(

--- a/src/notes/types.ts
+++ b/src/notes/types.ts
@@ -51,6 +51,21 @@ export interface AttachmentRef {
   url: string | null;
 }
 
+// Info passed to a caller-supplied attachmentLinkBuilder when rendering
+// markdown. The caller decides what URL/path to substitute for each attachment.
+export interface AttachmentLinkInfo {
+  identifier: string;
+  name: string;
+  contentType: string;
+}
+
+export interface ReadOptions {
+  // When provided, attachments in rendered markdown become
+  // `![${name}](${builder(info)})` instead of the default
+  // `![attachment](attachment:${id}?type=${uti})` placeholder URI.
+  attachmentLinkBuilder?: (info: AttachmentLinkInfo) => string;
+}
+
 export type NoteSortField = "title" | "createdAt" | "modifiedAt";
 
 import type { SortOrder } from "../types.ts";

--- a/tests/notes-attachment-fk.test.ts
+++ b/tests/notes-attachment-fk.test.ts
@@ -1,0 +1,130 @@
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Notes } from "../src/index.ts";
+
+// Build a minimal NoteStore.sqlite where the schema has BOTH ZNOTE and
+// ZNOTE1 columns, but only ZNOTE is populated on attachment rows. This is
+// the macOS 15+ shape that motivated the original bug report (#31).
+
+const TMP_DIR = join(
+  tmpdir(),
+  `macos-ts-attachment-fk-${process.pid}-${Date.now()}`,
+);
+const DB_PATH = join(TMP_DIR, "NoteStore.sqlite");
+
+const ENT_ACCOUNT = 1;
+const ENT_FOLDER = 2;
+const ENT_NOTE = 3;
+const ENT_ATTACHMENT = 5;
+
+beforeAll(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+
+  const db = new Database(DB_PATH);
+  db.exec(`
+    CREATE TABLE Z_PRIMARYKEY (
+      Z_ENT INTEGER PRIMARY KEY,
+      Z_NAME VARCHAR,
+      Z_SUPER INTEGER,
+      Z_MAX INTEGER
+    );
+
+    CREATE TABLE ZICCLOUDSYNCINGOBJECT (
+      Z_PK INTEGER PRIMARY KEY,
+      Z_ENT INTEGER,
+      Z_OPT INTEGER,
+      ZNAME VARCHAR,
+      ZTITLE2 VARCHAR,
+      ZPARENT INTEGER,
+      ZMARKEDFORDELETION INTEGER DEFAULT 0,
+      ZTITLE1 VARCHAR,
+      ZSNIPPET VARCHAR,
+      ZFOLDER INTEGER,
+      ZACCOUNT2 INTEGER,
+      ZCREATIONDATE1 TIMESTAMP,
+      ZMODIFICATIONDATE1 TIMESTAMP,
+      ZISPASSWORDPROTECTED INTEGER DEFAULT 0,
+      ZIDENTIFIER VARCHAR,
+      ZFILENAME VARCHAR,
+      ZTYPEUTI VARCHAR,
+      ZNOTE INTEGER,
+      ZNOTE1 INTEGER,
+      ZMEDIA INTEGER,
+      ZMERGEABLEDATA1 BLOB
+    );
+
+    CREATE TABLE ZICNOTEDATA (
+      Z_PK INTEGER PRIMARY KEY,
+      Z_ENT INTEGER,
+      Z_OPT INTEGER,
+      ZNOTE INTEGER,
+      ZDATA BLOB
+    );
+
+    INSERT INTO Z_PRIMARYKEY (Z_ENT, Z_NAME, Z_SUPER, Z_MAX) VALUES
+      (${ENT_ACCOUNT}, 'ICAccount', 0, 0),
+      (${ENT_FOLDER}, 'ICFolder', 0, 0),
+      (${ENT_NOTE}, 'ICNote', 0, 0),
+      (${ENT_ATTACHMENT}, 'ICAttachment', 0, 0);
+  `);
+
+  db.query(
+    `INSERT INTO ZICCLOUDSYNCINGOBJECT (Z_PK, Z_ENT, Z_OPT, ZNAME)
+     VALUES (1, ${ENT_ACCOUNT}, 1, 'iCloud')`,
+  ).run();
+
+  db.query(
+    `INSERT INTO ZICCLOUDSYNCINGOBJECT
+       (Z_PK, Z_ENT, Z_OPT, ZTITLE2, ZPARENT, ZMARKEDFORDELETION)
+     VALUES (10, ${ENT_FOLDER}, 1, 'Notes', 1, 0)`,
+  ).run();
+
+  db.query(
+    `INSERT INTO ZICCLOUDSYNCINGOBJECT
+       (Z_PK, Z_ENT, Z_OPT, ZTITLE1, ZSNIPPET, ZFOLDER, ZACCOUNT2,
+        ZCREATIONDATE1, ZMODIFICATIONDATE1, ZISPASSWORDPROTECTED)
+     VALUES (100, ${ENT_NOTE}, 1, 'Note', '', 10, 1, 0, 0, 0)`,
+  ).run();
+
+  // Attachment rows: ZNOTE populated, ZNOTE1 NULL — the macOS 15+ shape.
+  db.query(
+    `INSERT INTO ZICCLOUDSYNCINGOBJECT
+       (Z_PK, Z_ENT, Z_OPT, ZIDENTIFIER, ZFILENAME, ZTYPEUTI, ZNOTE, ZNOTE1)
+     VALUES (200, ${ENT_ATTACHMENT}, 1, 'A1', 'a.jpg', 'public.jpeg', 100, NULL),
+            (201, ${ENT_ATTACHMENT}, 1, 'A2', 'b.png', 'public.png',  100, NULL)`,
+  ).run();
+
+  db.close();
+});
+
+afterAll(() => {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+describe("attachment FK column discovery (ZNOTE vs ZNOTE1)", () => {
+  test("listAttachments returns rows when only ZNOTE is populated", () => {
+    const notes = new Notes({ dbPath: DB_PATH, containerPath: TMP_DIR });
+    try {
+      const attachments = notes.listAttachments(100);
+      expect(attachments).toHaveLength(2);
+      const ids = attachments.map((a) => a.identifier).sort();
+      expect(ids).toEqual(["A1", "A2"]);
+    } finally {
+      notes.close();
+    }
+  });
+
+  test("attachment.name uses ZFILENAME when set", () => {
+    const notes = new Notes({ dbPath: DB_PATH, containerPath: TMP_DIR });
+    try {
+      const attachments = notes.listAttachments(100);
+      const names = attachments.map((a) => a.name).sort();
+      expect(names).toEqual(["a.jpg", "b.png"]);
+    } finally {
+      notes.close();
+    }
+  });
+});

--- a/tests/notes-conversion.test.ts
+++ b/tests/notes-conversion.test.ts
@@ -5,6 +5,7 @@ import type {
   DecodedNote,
   DecodedTable,
 } from "../src/notes/protobuf/decode.ts";
+import type { AttachmentRef } from "../src/notes/types.ts";
 
 function note(text: string, runs: DecodedAttributeRun[]): DecodedNote {
   return { text, attributeRuns: runs };
@@ -239,6 +240,65 @@ describe("noteToMarkdown", () => {
       ]),
     );
     expect(md).toContain("![attachment](attachment:UUID-123?type=public.jpeg)");
+  });
+
+  test("renders attachment as ![name](builtUrl) when attachmentLinkBuilder is provided", () => {
+    const decoded = note("Before\n\uFFFC\nAfter\n", [
+      { length: 7 },
+      {
+        length: 1,
+        attachmentInfo: {
+          attachmentIdentifier: "UUID-123",
+          typeUti: "public.jpeg",
+        },
+      },
+      { length: 1 },
+      { length: 6 },
+    ]);
+    const attachments: AttachmentRef[] = [
+      {
+        id: 42,
+        identifier: "UUID-123",
+        name: "diagram.png",
+        contentType: "public.jpeg",
+        url: null,
+      },
+    ];
+    let received:
+      | { identifier: string; name: string; contentType: string }
+      | undefined;
+    const md = noteToMarkdown(decoded, undefined, attachments, {
+      attachmentLinkBuilder: (info) => {
+        received = info;
+        return `./attachments/${info.name}`;
+      },
+    });
+    expect(md).toContain("![diagram.png](./attachments/diagram.png)");
+    expect(md).not.toContain("attachment:UUID-123");
+    expect(received).toEqual({
+      identifier: "UUID-123",
+      name: "diagram.png",
+      contentType: "public.jpeg",
+    });
+  });
+
+  test("falls back to placeholder when builder is provided but no matching attachment row", () => {
+    const md = noteToMarkdown(
+      note("\uFFFC\n", [
+        {
+          length: 1,
+          attachmentInfo: {
+            attachmentIdentifier: "UNKNOWN",
+            typeUti: "public.png",
+          },
+        },
+        { length: 1 },
+      ]),
+      undefined,
+      [],
+      { attachmentLinkBuilder: () => "./somewhere" },
+    );
+    expect(md).toContain("![attachment](attachment:UNKNOWN?type=public.png)");
   });
 
   test("renders mixed formatting in one note", () => {

--- a/tests/notes.test.ts
+++ b/tests/notes.test.ts
@@ -404,6 +404,34 @@ describe("listAttachments", () => {
     const attachments = db.listAttachments(100);
     expect(attachments).toHaveLength(0);
   });
+
+  test("attachment.name falls back to ZMEDIA filename when ZFILENAME is NULL", () => {
+    // Note 110's attachment row has ZFILENAME=NULL but its ZMEDIA row has
+    // ZFILENAME='photo.jpg' — getAttachments uses COALESCE on the join.
+    const attachments = db.listAttachments(110);
+    expect(attachments[0]?.name).toBe("photo.jpg");
+  });
+});
+
+// ============================================================================
+// resolveAttachment()
+// ============================================================================
+
+describe("resolveAttachment", () => {
+  test("returns { path } for an attachment that exists on disk", () => {
+    const result = db.resolveAttachment("ATTACH-UUID-001");
+    expect("path" in result).toBe(true);
+    if ("path" in result) {
+      expect(result.path).not.toStartWith("file://");
+      expect(result.path).toContain("MEDIA-UUID-001");
+      expect(result.path).toContain("photo.jpg");
+    }
+  });
+
+  test("returns { error: 'not-found' } for an unknown identifier", () => {
+    const result = db.resolveAttachment("NONEXISTENT-UUID");
+    expect(result).toEqual({ error: "not-found" });
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
Closes #31.

## Summary
- **Discover the attachment→note FK at runtime.** Schemas where the FK lives in `ZNOTE` rather than `ZNOTE1` previously got `[]` from `listAttachments()` for every note. Same `pickDateColumn` pattern used for date columns.
- **`ReadOptions.attachmentLinkBuilder`** lets callers replace the opaque `![attachment](attachment:UUID?type=...)` placeholder with a real path — `![${name}](${builder(info)})`. Default behavior unchanged for back-compat.
- **`AttachmentResolver.resolveDetailed()`** returns `{ path } | { error: 'not-found' | 'permission-denied' }` so consumers can distinguish silent permission failures from genuine misses. Exposed via `Notes.resolveAttachment()`. Old `resolve()` still returns `string | null`.
- **`getAttachments` SQL** now coalesces an empty `att.ZFILENAME` with `media.ZFILENAME` via the existing `ZMEDIA` FK, so consumers get real filenames like `IMG_0976.jpeg` instead of falling back to numeric IDs.

Bumps `package.json` to `0.10.0` so the auto-release picks it up on merge.

## Test plan
- [x] `bun test` — 252 pass, 0 fail
- [x] `bun run lint` — clean
- [x] End-to-end consumer test against a 605-note Apple Notes DB on macOS 15: produced 115 attachment dirs / 428 files, with `.md` files referencing them via relative paths

## Notes
- The new `read()` overloads disambiguate single-arg `PaginationOptions` vs `ReadOptions` by looking for `offset|limit` keys, since both are object literals.
- `resolveDetailed` only flags `permission-denied` if it actually saw an `EACCES`/`EPERM`. Plain "no match" still returns `not-found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)