### PR TITLE
Bump version to 0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

- Bumps version 0.10.3 → 0.10.4 to trigger auto-release.
- #38 (inline-attachments filter on `listAttachments`) landed without a version bump, so the published 0.10.3 doesn't include it. This re-publishes to pick it up.

## Test plan

- [ ] CI passes
- [ ] Auto-release workflow publishes 0.10.4 to npm
- [ ] Verify `npm view macos-ts version` returns 0.10.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)