### PR TITLE
Drop typescript peer dep and move devDep to TS 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,9 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@types/bun": "latest",
-      },
-      "peerDependencies": {
-        "typescript": "^5",
+        "typescript": "^6",
       },
     },
   },
@@ -236,7 +234,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.10.7",
+  "version": "0.11.0",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",
@@ -52,10 +52,8 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
-    "@types/bun": "latest"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
+    "@types/bun": "latest",
+    "typescript": "^6"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

End users installing downstream packages like `botholomew` globally (`bun install -g botholomew`) hit a spurious peer-dependency warning:

```
warn: incorrect peer dependency "typescript@5.9.3"
```

`macos-ts` ships raw `.ts` from `src/` and doesn't actually require any specific TypeScript version on the consumer side — bun executes `.ts` natively. The `peerDependencies.typescript` declaration is just generating noise.

## Changes

- Remove `peerDependencies.typescript` entirely.
- Add `typescript: ^6` to `devDependencies` (was being resolved implicitly via some other path).
- Bump version to `0.11.0` (minor bump — peer dep removed, devDep bumped to TS 6).

Parallel PRs going out in `membot` and `@evantahler/mcpx` for the same reason.

`bun run lint` and `bun test` both pass cleanly on TS 6.