### PR TITLE
Add Messages.send() to send iMessage/SMS via osascript

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ macos-ts — TypeScript package for accessing macOS data (Notes, Photos, iMessag
 
 - **Runtime**: Bun (uses bun:sqlite, node:zlib built-ins)
 - **Access method**: Read-only SQLite against macOS databases
-- **No AppleScript/JXA** — all access is through the database
+- **No AppleScript for reads** — all *reading* is through the database. The one exception is `Messages.send()` (sending a message), which has no DB path and must drive Messages.app via AppleScript/osascript (see the Messages write-path note below)
 - **Structure**: Each data source lives in its own `src/<source>/` directory (e.g. `src/notes/`)
 - **Note content**: Stored as gzip-compressed protobuf in `ZICNOTEDATA.ZDATA`, decoded via protobufjs
 - **Markdown conversion**: Custom converter walks protobuf AttributeRun entries to emit markdown
@@ -31,6 +31,7 @@ macos-ts — TypeScript package for accessing macOS data (Notes, Photos, iMessag
 - **Messages database**: `~/Library/Messages/chat.db` — standard relational schema (handle, chat, message, attachment tables joined via junction tables)
 - **Mac timestamps (Messages)**: Nanoseconds since 2001-01-01 (divide by 1e9, then add 978307200 for Unix epoch)
 - **Message text**: Stored in `text` column, or as NSArchiver-encoded `attributedBody` blob when rich text
+- **Sending messages (the lone write path)**: `Messages.send({ text, handle | chatId, service? })` is the only non-read-only operation in the package. `chat.db` is a passive log — writing to it transmits nothing — so sending drives Messages.app via Apple Events: `Bun.spawnSync(["osascript", "-e", SEND_APPLESCRIPT, target, text, service, mode])`. **AppleScript, not JXA**: on macOS 26 the JXA bridge to Messages is broken (`Application("Messages").services()` throws "Application isn't running" even when it is). The AppleScript form resolves `1st service whose service type is iMessage|SMS` then `participant <handle>`, or `chat id <guid>` for chat mode. User data (recipient, body) is passed as **argv** bound to `on run {target, body, kind, mode}`, never interpolated into the script, to avoid injection. Logic lives in `src/messages/send.ts`: `buildSendArgs` (pure validation, fixture-testable) and `classifySendError` (maps osascript failures — TCC error `-1743`/"Not authorized" → `MessageSendError` with `category: access_denied`). The AppleScript recipient-resolution itself can't be fixture-tested and must be verified on a real Mac (validated end-to-end on macOS 26.3). Messages.app must be running; first send triggers a macOS **Automation** TCC prompt; there is **no delivery confirmation** (exit 0 ≠ delivered). MCP tool `send_message` uses `writeAnnotations` (in `src/mcp-helpers.ts`), not `readOnlyAnnotations`.
 - **Contacts database**: Apple stores contacts in per-account source databases at `~/Library/Application Support/AddressBook/Sources/<UUID>/AddressBook-v22.abcddb`. The root `AddressBook-v22.abcddb` is typically empty. The connection logic auto-discovers the source DB with the most contacts. Core Data schema with ZABCDRECORD as the main table
 - **Contacts entity types**: Z_ENT=22 for contacts, Z_ENT=19 for groups (from Z_PRIMARYKEY table)
 - **Contact details**: Stored in separate tables (ZABCDEMAILADDRESS, ZABCDPHONENUMBER, ZABCDPOSTALADDRESS, etc.) with ZOWNER FK to ZABCDRECORD.Z_PK
@@ -74,6 +75,7 @@ macos-ts — TypeScript package for accessing macOS data (Notes, Photos, iMessag
 - `src/messages/database/connection.ts` — Messages SQLite database connection
 - `src/messages/database/queries.ts` — Messages SQL queries and nanosecond time conversion
 - `src/messages/database/reader.ts` — Messages query execution, row mapping, and attributedBody decoding
+- `src/messages/send.ts` — Send-message logic: `SEND_APPLESCRIPT` script, `buildSendArgs` (validation/arg resolution), `classifySendError` (osascript failure → `MessageSendError`)
 - `src/contacts/contacts.ts` — Main `Contacts` class (public API for Apple Contacts)
 - `src/contacts/index.ts` — Contacts barrel export
 - `src/contacts/types.ts` — TypeScript type definitions for Contacts

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # macos-ts
 
-TypeScript package for accessing macOS data via direct SQLite access — no AppleScript, no network calls. Currently supports **Apple Notes**, **Apple Messages** (iMessage/SMS), **Apple Contacts**, and **Apple Photos**.
+TypeScript package for accessing macOS data via direct SQLite access — reads use no AppleScript and make no network calls. Currently supports **Apple Notes**, **Apple Messages** (iMessage/SMS), **Apple Contacts**, and **Apple Photos**. Sending an iMessage/SMS is the one write operation, and it is the only feature that uses Apple Events (osascript); see [Messages](#messages).
 
 ## Requirements
 
@@ -96,9 +96,26 @@ const inChat = db.search("dinner tonight", { chatId: 1, limit: 10 });
 // Attachments
 const attachments = db.attachments(messageId);
 
+// Send a new message (the only write operation in this package).
+// Target a raw handle (phone/email)...
+db.send({ handle: "+15551234567", text: "On my way!" });
+db.send({ handle: "friend@example.com", text: "Hi", service: "SMS" });
+// ...or an existing conversation by chatId (service taken from the chat):
+db.send({ chatId: 1, text: "Sounds good" });
+
 // Cleanup
 db.close();
 ```
+
+> **Sending requires Apple Events.** `chat.db` is only a passive log, so sending
+> a message means driving Messages.app via `osascript` (AppleScript). Consequences:
+>
+> - **macOS Automation permission** is required — the first `send()` triggers a
+>   one-time TCC prompt to allow your terminal/host app to control "Messages".
+> - **No delivery confirmation.** A successful return means the request was
+>   dispatched, not that it was delivered. Failures throw `MessageSendError`.
+> - **Irreversible.** A sent message cannot be unsent.
+> - Messages.app must be open and signed in.
 
 ### Contacts
 
@@ -235,6 +252,7 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 - **get_message** — Get a single message by ID
 - **search_messages** — Search message text across all conversations or within a specific chat
 - **list_message_attachments** — List attachments for a specific message
+- **send_message** — Send a new iMessage/SMS to a handle or chatId (the only write tool; requires macOS Automation permission, gives no delivery confirmation, and cannot be undone)
 
 #### Contacts
 
@@ -291,7 +309,7 @@ Errors: `DatabaseNotFoundError` (missing DB or no Full Disk Access), `NoteNotFou
 
 **Messages**: Pass `dbPath` to `new Messages()` to override auto-detection (defaults to `~/Library/Messages/chat.db`).
 
-Errors: `DatabaseNotFoundError`, `ChatNotFoundError`, `MessageNotFoundError`.
+Errors: `DatabaseNotFoundError`, `ChatNotFoundError`, `MessageNotFoundError`, `MessageSendError` (sending failed; `category` is `access_denied` when macOS Automation permission is missing, otherwise `internal`).
 
 **Contacts**: Pass `dbPath` to `new Contacts()` to override auto-detection (defaults to `~/Library/Application Support/AddressBook/AddressBook-v22.abcddb`). Labels are automatically cleaned from Apple's internal `_$!<Label>!$_` format to plain strings (e.g., "Home", "Work", "Mobile").
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,12 +38,16 @@ export type {
   MessageAttachment,
   MessageId,
   MessageMeta,
+  MessageService,
   MessagesOptions,
   SearchMessagesOptions,
+  SendMessageOptions,
+  SendMessageResult,
 } from "./messages/index.ts";
 export {
   ChatNotFoundError,
   MessageNotFoundError,
+  MessageSendError,
   Messages,
 } from "./messages/index.ts";
 export type {

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -13,6 +13,20 @@ export const readOnlyAnnotations = {
   openWorldHint: false as const,
 };
 
+/**
+ * Annotations for a write/command tool with an external side effect (e.g.
+ * sending a message). Not read-only, not idempotent (each call acts again), and
+ * open-world since it reaches beyond this Mac. `destructiveHint` stays false —
+ * it creates rather than deletes local data — but such actions are typically
+ * irreversible, so say so in the tool description.
+ */
+export const writeAnnotations = {
+  readOnlyHint: false as const,
+  destructiveHint: false as const,
+  idempotentHint: false as const,
+  openWorldHint: true as const,
+};
+
 export function toolError(e: MacOSError) {
   return {
     isError: true as const,

--- a/src/messages/errors.ts
+++ b/src/messages/errors.ts
@@ -20,3 +20,23 @@ export class MessageNotFoundError extends MacOSError {
     this.name = "MessageNotFoundError";
   }
 }
+
+/**
+ * Raised when sending a message via osascript fails. `category` is
+ * "access_denied" when macOS blocks the Apple Events automation (TCC),
+ * "invalid_input" for bad arguments, and "internal" for any other osascript
+ * failure.
+ */
+export class MessageSendError extends MacOSError {
+  constructor(
+    message: string,
+    options?: {
+      category?: "internal" | "access_denied" | "invalid_input";
+      retryable?: boolean;
+      recovery?: string;
+    },
+  ) {
+    super(message, options);
+    this.name = "MessageSendError";
+  }
+}

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,4 +1,8 @@
-export { ChatNotFoundError, MessageNotFoundError } from "./errors.ts";
+export {
+  ChatNotFoundError,
+  MessageNotFoundError,
+  MessageSendError,
+} from "./errors.ts";
 export type { MessagesOptions } from "./messages.ts";
 export { Messages } from "./messages.ts";
 export type {
@@ -13,6 +17,9 @@ export type {
   MessageAttachment,
   MessageId,
   MessageMeta,
+  MessageService,
   SearchMessagesOptions,
+  SendMessageOptions,
+  SendMessageResult,
   SortOrder,
 } from "./types.ts";

--- a/src/messages/mcp-tools.ts
+++ b/src/messages/mcp-tools.ts
@@ -3,12 +3,14 @@ import {
   type McpServerInstance,
   readOnlyAnnotations,
   wrapTool,
+  writeAnnotations,
 } from "../mcp-helpers.ts";
 import type { Messages } from "./messages.ts";
 
 export const messagesCapability = {
   name: "iMessage / SMS",
-  description: "Read-only access to iMessage and SMS conversations on this Mac",
+  description:
+    "Read iMessage and SMS conversations on this Mac, and send new messages",
   tools: [
     "list_chats",
     "get_chat",
@@ -17,6 +19,7 @@ export const messagesCapability = {
     "search_messages",
     "list_message_attachments",
     "list_handles",
+    "send_message",
   ],
   startWith: "list_chats or search_messages",
 };
@@ -284,5 +287,50 @@ export function registerMessagesTools(
       },
     },
     async ({ messageId }) => wrapTool(() => messages.attachments(messageId)),
+  );
+
+  server.registerTool(
+    "send_message",
+    {
+      title: "Send a message",
+      description:
+        "Send a new iMessage or SMS via Messages.app. This actually delivers a real message and CANNOT be undone — confirm the recipient and text first. Target either an existing conversation by chatId (from list_chats) or a raw handle (phone number or email); provide exactly one. When sending by chatId the service is taken from the chat; when sending by handle it defaults to iMessage (set service to 'SMS' to force a text). The first send prompts for macOS Automation permission, and macOS gives no delivery confirmation (success means the request was dispatched, not delivered). Follow-up: use list_messages on the chat to confirm it appears.",
+      annotations: writeAnnotations,
+      inputSchema: {
+        text: z
+          .string()
+          .min(1)
+          .describe("The message body to send. Must be non-empty."),
+        handle: z
+          .string()
+          .optional()
+          .describe(
+            "Recipient phone number or email. Provide this OR chatId, not both.",
+          ),
+        chatId: z
+          .number()
+          .int()
+          .optional()
+          .describe(
+            "Numeric chat ID (from list_chats) to send into. Provide this OR handle, not both.",
+          ),
+        service: z
+          .enum(["iMessage", "SMS"])
+          .optional()
+          .describe(
+            "Service to use when sending by handle. Defaults to 'iMessage'. Ignored when chatId is given.",
+          ),
+      },
+    },
+    async ({ text, handle, chatId, service }) =>
+      wrapTool(
+        () => messages.send({ text, handle, chatId, service }),
+        [
+          {
+            tool: "list_messages",
+            description: "Read the conversation to confirm the message appears",
+          },
+        ],
+      ),
   );
 }

--- a/src/messages/messages.ts
+++ b/src/messages/messages.ts
@@ -3,6 +3,7 @@ import { openFullDiskAccessSettings } from "../errors.ts";
 import { openDatabase } from "./database/connection.ts";
 import { MessageReader } from "./database/reader.ts";
 import { ChatNotFoundError, MessageNotFoundError } from "./errors.ts";
+import { buildSendArgs, classifySendError, SEND_APPLESCRIPT } from "./send.ts";
 import type {
   Chat,
   Handle,
@@ -11,6 +12,8 @@ import type {
   MessageAttachment,
   MessageMeta,
   SearchMessagesOptions,
+  SendMessageOptions,
+  SendMessageResult,
 } from "./types.ts";
 
 export interface MessagesOptions {
@@ -58,6 +61,48 @@ export class Messages {
 
   attachments(messageId: number): MessageAttachment[] {
     return this.reader.listAttachments(messageId);
+  }
+
+  /**
+   * Sends an iMessage/SMS by driving Messages.app through Apple Events
+   * (`osascript -l JavaScript`). This is the only non-read-only operation in the
+   * package: the message cannot be unsent, and macOS gives no delivery
+   * confirmation (a successful return means osascript dispatched the request, not
+   * that it was delivered). The first call prompts for Automation permission.
+   *
+   * Target either an existing conversation (`chatId`, from {@link chats}) or a
+   * raw `handle` (phone/email). Throws `ChatNotFoundError` for an unknown
+   * `chatId`, `MacOSError` (`invalid_input`) for bad arguments, and
+   * `MessageSendError` if osascript fails.
+   */
+  send(options: SendMessageOptions): SendMessageResult {
+    // Resolve the chat (and validate it exists) before building args. Skipped
+    // when a handle is also supplied so buildSendArgs can report the conflict.
+    const chat =
+      options.chatId !== undefined && options.handle === undefined
+        ? this.getChat(options.chatId)
+        : undefined;
+
+    const { target, service, mode } = buildSendArgs(options, chat);
+
+    const result = Bun.spawnSync(
+      [
+        "osascript",
+        "-e",
+        SEND_APPLESCRIPT,
+        target,
+        options.text,
+        service,
+        mode,
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+
+    if (result.exitCode !== 0) {
+      throw classifySendError(result.exitCode ?? -1, result.stderr.toString());
+    }
+
+    return { to: target, service, mode };
   }
 
   close(): void {

--- a/src/messages/send.ts
+++ b/src/messages/send.ts
@@ -1,0 +1,133 @@
+import { MacOSError } from "../errors.ts";
+import { MessageSendError } from "./errors.ts";
+import type { Chat, MessageService, SendMessageOptions } from "./types.ts";
+
+export interface SendArgs {
+  /** Handle (phone/email) in handle mode, or chat guid in chat mode. */
+  target: string;
+  service: MessageService;
+  mode: "handle" | "chat";
+}
+
+/**
+ * AppleScript program run via `osascript -e SEND_APPLESCRIPT <target> <body> <kind> <mode>`.
+ *
+ * The trailing CLI arguments bind positionally to `on run {target, body, kind, mode}`.
+ * User-supplied values (the recipient and the message body) are passed as argv
+ * — never interpolated into the script source — so a message containing quotes
+ * or script-like text cannot inject into the automation.
+ *
+ * Why AppleScript and not JXA: on macOS 26 the JavaScript-for-Automation bridge
+ * to Messages is broken — `Application("Messages").services()` throws
+ * "Application isn't running" even when it is, and `.whose()` is unavailable on
+ * the element accessor. The AppleScript `whose`-clause resolution below works.
+ *
+ * NOTE: the `1st service whose service type is …` / `participant … of …` /
+ * `chat id …` resolution is the one part that cannot be exercised by the test
+ * fixtures (it drives a live Messages.app). It was validated end-to-end against
+ * a real Messages.app; if Apple changes the Messages scripting dictionary, this
+ * is the line to revisit.
+ */
+export const SEND_APPLESCRIPT = `on run {target, body, kind, mode}
+  tell application "Messages"
+    if mode is "chat" then
+      send body to chat id target
+    else
+      if kind is "SMS" then
+        set targetService to 1st service whose service type is SMS
+      else
+        set targetService to 1st service whose service type is iMessage
+      end if
+      send body to participant target of targetService
+    end if
+  end tell
+end run`;
+
+/**
+ * Validates send options and resolves the osascript arguments. Pure and
+ * synchronous so it can be unit-tested without spawning osascript. When sending
+ * by `chatId`, the caller must resolve and pass the `chat` first.
+ */
+export function buildSendArgs(
+  options: SendMessageOptions,
+  chat?: Chat,
+): SendArgs {
+  const hasHandle =
+    typeof options.handle === "string" && options.handle.length > 0;
+  const hasChat = options.chatId !== undefined;
+
+  if (hasHandle === hasChat) {
+    throw new MacOSError(
+      "Provide exactly one of `handle` or `chatId` to send a message.",
+      {
+        category: "invalid_input",
+        recovery:
+          "Pass `handle` (a phone number or email) OR `chatId` (from list_chats), but not both.",
+      },
+    );
+  }
+
+  if (typeof options.text !== "string" || options.text.length === 0) {
+    throw new MacOSError("Message text must be a non-empty string.", {
+      category: "invalid_input",
+      recovery: "Pass a non-empty `text` value.",
+    });
+  }
+
+  if (hasChat) {
+    if (!chat) {
+      throw new MacOSError(
+        "Chat must be resolved before building send arguments.",
+        { category: "internal" },
+      );
+    }
+    return {
+      target: chat.guid,
+      service: chat.serviceName === "SMS" ? "SMS" : "iMessage",
+      mode: "chat",
+    };
+  }
+
+  return {
+    target: options.handle as string,
+    service: options.service ?? "iMessage",
+    mode: "handle",
+  };
+}
+
+/**
+ * Maps a failed osascript invocation to a {@link MessageSendError}, detecting
+ * the TCC/Automation-denied case so the recovery hint can point at the right
+ * System Settings pane.
+ */
+export function classifySendError(
+  exitCode: number,
+  stderr: string,
+): MessageSendError {
+  const denied =
+    stderr.includes("-1743") ||
+    /not authori[sz]ed to send apple events/i.test(stderr) ||
+    /not allowed to send apple events/i.test(stderr);
+
+  if (denied) {
+    return new MessageSendError(
+      `Messages automation is not authorized: ${stderr.trim()}`,
+      {
+        category: "access_denied",
+        retryable: true,
+        recovery:
+          'Grant Automation access for "Messages" to your terminal/host app in System Settings > Privacy & Security > Automation, then retry.',
+      },
+    );
+  }
+
+  return new MessageSendError(
+    `Failed to send message (osascript exit ${exitCode}): ${stderr.trim() || "no error output"}`,
+    {
+      category: "internal",
+      retryable: true,
+      recovery:
+        "Ensure Messages.app is open and signed in, and that the recipient handle or chat is valid and reachable.",
+    },
+  );
+}

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -69,3 +69,22 @@ export interface SearchMessagesOptions {
   chatId?: number;
   limit?: number;
 }
+
+export type MessageService = "iMessage" | "SMS";
+
+export interface SendMessageOptions {
+  text: string;
+  /** Recipient phone number or email. Mutually exclusive with `chatId`. */
+  handle?: string;
+  /** Existing conversation to send into. Mutually exclusive with `handle`. */
+  chatId?: number;
+  /** Service to use when sending by `handle`. Defaults to "iMessage". */
+  service?: MessageService;
+}
+
+export interface SendMessageResult {
+  /** The handle or chat guid the message was sent to. */
+  to: string;
+  service: MessageService;
+  mode: "handle" | "chat";
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -72,9 +72,9 @@ function getErrorJson(result: any) {
 // ============================================================================
 
 describe("server metadata", () => {
-  test("server exposes 26 tools", async () => {
+  test("server exposes 27 tools", async () => {
     const { tools } = await client.listTools();
-    expect(tools).toHaveLength(26);
+    expect(tools).toHaveLength(27);
   });
 
   test("each tool has a description", async () => {
@@ -115,6 +115,7 @@ describe("server metadata", () => {
       "search_messages",
       "search_notes",
       "search_photos",
+      "send_message",
     ]);
   });
 
@@ -130,14 +131,21 @@ describe("server metadata", () => {
     expect(props.limit?.description).toBeTruthy();
   });
 
-  test("all tools have readOnlyHint annotation", async () => {
+  // send_message is the lone write/command tool; everything else is read-only.
+  const WRITE_TOOLS = new Set(["send_message"]);
+
+  test("read tools are read-only and the write tool is annotated as such", async () => {
     const { tools } = await client.listTools();
     for (const tool of tools) {
       // biome-ignore lint/suspicious/noExplicitAny: test
       const annotations = (tool as any).annotations;
-      if (annotations) {
+      if (!annotations) continue;
+      expect(annotations.destructiveHint).toBe(false);
+      if (WRITE_TOOLS.has(tool.name)) {
+        expect(annotations.readOnlyHint).toBe(false);
+        expect(annotations.openWorldHint).toBe(true);
+      } else {
         expect(annotations.readOnlyHint).toBe(true);
-        expect(annotations.destructiveHint).toBe(false);
       }
     }
   });

--- a/tests/messages-send.test.ts
+++ b/tests/messages-send.test.ts
@@ -1,0 +1,124 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { MacOSError } from "../src/errors.ts";
+import { Messages } from "../src/index.ts";
+import { ChatNotFoundError, MessageSendError } from "../src/messages/errors.ts";
+import { buildSendArgs, classifySendError } from "../src/messages/send.ts";
+import type { Chat } from "../src/messages/types.ts";
+
+const FIXTURE_DB = resolve(import.meta.dir, "fixtures/chat.db");
+
+// The actual osascript dispatch cannot be exercised against a fixture (it would
+// drive a real Messages.app). These tests cover everything around it: argument
+// validation, chat resolution, and error classification.
+
+const fakeChat = (overrides: Partial<Chat> = {}): Chat => ({
+  id: 1,
+  guid: "iMessage;-;+15551234567",
+  displayName: "Alice",
+  chatIdentifier: "+15551234567",
+  isGroup: false,
+  serviceName: "iMessage",
+  participants: ["+15551234567"],
+  lastMessageDate: new Date(),
+  ...overrides,
+});
+
+describe("buildSendArgs", () => {
+  test("resolves a handle send (default service iMessage)", () => {
+    const args = buildSendArgs({ text: "hi", handle: "+15551234567" });
+    expect(args).toEqual({
+      target: "+15551234567",
+      service: "iMessage",
+      mode: "handle",
+    });
+  });
+
+  test("honors an explicit SMS service for handle sends", () => {
+    const args = buildSendArgs({
+      text: "hi",
+      handle: "+15551234567",
+      service: "SMS",
+    });
+    expect(args.service).toBe("SMS");
+  });
+
+  test("resolves a chat send and derives the service from the chat", () => {
+    const args = buildSendArgs(
+      { text: "hi", chatId: 1 },
+      fakeChat({ guid: "iMessage;-;group", serviceName: "iMessage" }),
+    );
+    expect(args).toEqual({
+      target: "iMessage;-;group",
+      service: "iMessage",
+      mode: "chat",
+    });
+  });
+
+  test("derives SMS service from an SMS chat", () => {
+    const args = buildSendArgs(
+      { text: "hi", chatId: 1 },
+      fakeChat({ serviceName: "SMS" }),
+    );
+    expect(args.service).toBe("SMS");
+  });
+
+  test("rejects when both handle and chatId are provided", () => {
+    expect(() =>
+      buildSendArgs({ text: "hi", handle: "+1", chatId: 1 }, fakeChat()),
+    ).toThrow(MacOSError);
+    try {
+      buildSendArgs({ text: "hi", handle: "+1", chatId: 1 }, fakeChat());
+    } catch (e) {
+      expect((e as MacOSError).category).toBe("invalid_input");
+    }
+  });
+
+  test("rejects when neither handle nor chatId is provided", () => {
+    expect(() => buildSendArgs({ text: "hi" })).toThrow(MacOSError);
+  });
+
+  test("rejects empty text", () => {
+    expect(() => buildSendArgs({ text: "", handle: "+1" })).toThrow(MacOSError);
+  });
+});
+
+describe("classifySendError", () => {
+  test("flags TCC/Automation denial as access_denied", () => {
+    const err = classifySendError(
+      1,
+      "execution error: Not authorized to send Apple events to Messages. (-1743)",
+    );
+    expect(err).toBeInstanceOf(MessageSendError);
+    expect(err.category).toBe("access_denied");
+    expect(err.recovery).toContain("Automation");
+  });
+
+  test("treats other failures as retryable internal errors", () => {
+    const err = classifySendError(1, "some other osascript failure");
+    expect(err.category).toBe("internal");
+    expect(err.retryable).toBe(true);
+  });
+});
+
+describe("Messages.send", () => {
+  let db: Messages;
+
+  beforeAll(() => {
+    db = new Messages({ dbPath: FIXTURE_DB });
+  });
+
+  afterAll(() => {
+    db.close();
+  });
+
+  test("throws ChatNotFoundError for an unknown chatId before dispatching", () => {
+    expect(() => db.send({ text: "hi", chatId: 999999 })).toThrow(
+      ChatNotFoundError,
+    );
+  });
+
+  test("rejects bad arguments before dispatching", () => {
+    expect(() => db.send({ text: "hi" })).toThrow(MacOSError);
+  });
+});


### PR DESCRIPTION
Adds the package's first write operation: `Messages.send({ text, handle | chatId, service? })` plus a `send_message` MCP tool, targeting either a raw handle (phone/email) or an existing `chatId`. Because `chat.db` is only a passive log, sending drives Messages.app through AppleScript via `osascript` — AppleScript rather than JXA because the JXA bridge to Messages is broken on macOS 26, and user data is passed as argv (never interpolated) to stay injection-safe. Includes a new `MessageSendError` that detects TCC/Automation denial, a `writeAnnotations` set for the non-read-only tool, send option/result types, and barrel exports. The lone write path is documented in README/CLAUDE with its caveats (Automation permission, no delivery confirmation, irreversible) and the version is bumped 0.12.0 → 0.13.0. Verified end-to-end on macOS 26.3 (real iMessage delivered); lint clean and all 292 tests pass, including new coverage for argument validation and osascript-error classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)