### PR TITLE
Add "text message" wording to send_message tool description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/src/messages/mcp-tools.ts
+++ b/src/messages/mcp-tools.ts
@@ -294,7 +294,7 @@ export function registerMessagesTools(
     {
       title: "Send a message",
       description:
-        "Send a new iMessage or SMS via Messages.app. This actually delivers a real message and CANNOT be undone — confirm the recipient and text first. Target either an existing conversation by chatId (from list_chats) or a raw handle (phone number or email); provide exactly one. When sending by chatId the service is taken from the chat; when sending by handle it defaults to iMessage (set service to 'SMS' to force a text). The first send prompts for macOS Automation permission, and macOS gives no delivery confirmation (success means the request was dispatched, not delivered). Follow-up: use list_messages on the chat to confirm it appears.",
+        "Send a new text message (iMessage or SMS) via Messages.app — text someone by phone number or email. This actually delivers a real message and CANNOT be undone — confirm the recipient and text first. Target either an existing conversation by chatId (from list_chats) or a raw handle (phone number or email); provide exactly one. When sending by chatId the service is taken from the chat; when sending by handle it defaults to iMessage (set service to 'SMS' to force a text). The first send prompts for macOS Automation permission, and macOS gives no delivery confirmation (success means the request was dispatched, not delivered). Follow-up: use list_messages on the chat to confirm it appears.",
       annotations: writeAnnotations,
       inputSchema: {
         text: z


### PR DESCRIPTION
## Context

The `send_message` MCP tool's description used only "iMessage" and "SMS". Keyword/semantic tool search (e.g. ToolSearch) wouldn't reliably surface it for queries like "send a text message" since the common phrase "text message" / "text" was absent.

## Change

- Updated the `send_message` tool description in `src/messages/mcp-tools.ts` to open with "Send a new text message (iMessage or SMS) via Messages.app — text someone by phone number or email." All existing operational warnings (irreversibility, single-target, Automation prompt, no delivery confirmation) are unchanged.
- Bumped patch version `0.13.0` → `0.13.1`.

## Verification

- `bun run lint` — passes
- `bun test` — 292 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)