### PR TITLE
Include phones and emails inline in contact search results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ macos-ts — TypeScript package for accessing macOS data (Notes, Photos, iMessag
 - **Contacts database**: Apple stores contacts in per-account source databases at `~/Library/Application Support/AddressBook/Sources/<UUID>/AddressBook-v22.abcddb`. The root `AddressBook-v22.abcddb` is typically empty. The connection logic auto-discovers the source DB with the most contacts. Core Data schema with ZABCDRECORD as the main table
 - **Contacts entity types**: Z_ENT=22 for contacts, Z_ENT=19 for groups (from Z_PRIMARYKEY table)
 - **Contact details**: Stored in separate tables (ZABCDEMAILADDRESS, ZABCDPHONENUMBER, ZABCDPOSTALADDRESS, etc.) with ZOWNER FK to ZABCDRECORD.Z_PK
+- **Search enrichment**: `search()` / `search_contacts` returns the `ContactSummary` type — the lean `Contact` summary plus `phones` and `emails` arrays (the two contact methods people search for), fetched via two batched `..._FOR_OWNERS` queries (`reader.ts` `enrichWithContactMethods`) after the groupId filter + limit slice, so only returned rows are enriched. The broad `list_contacts` / `list_group_members` paths stay lean (`Contact`, no phones/emails). Full detail (addresses, social, notes, etc.) still requires `getContact`
 - **Mac timestamps (Contacts)**: Seconds since 2001-01-01 (same as Notes, uses macTimeToDate/dateToMacTime)
 - **Contact labels**: Apple stores built-in labels as `_$!<Label>!$_` — cleaned to plain strings by the reader
 - **Group membership**: Z_22PARENTGROUPS junction table (Z_22CONTACTS → contact PK, Z_19PARENTGROUPS1 → group PK)

--- a/README.md
+++ b/README.md
@@ -129,12 +129,15 @@ const allContacts = db.contacts();
 const sorted = db.contacts({ sortBy: "modifiedAt", order: "desc", limit: 10 });
 const inGroup = db.contacts({ groupId: 1 });
 
-// Search by name, organization, phone number, or email
+// Search by name, organization, phone number, or email.
+// Results include phones and emails inline (primary first).
 const results = db.search("John");
+console.log(results[0].phones); // [{ number, label, isPrimary }]
+console.log(results[0].emails); // [{ address, label, isPrimary }]
 const byPhone = db.search("555-1234");
 const byEmail = db.search("alice@example.com");
 
-// Get full contact details (emails, phones, addresses, etc.)
+// Get full contact details (addresses, social profiles, notes, etc.)
 const details = db.getContact(contactId);
 console.log(details.emails);     // [{ address, label, isPrimary }]
 console.log(details.phones);     // [{ number, label, isPrimary }]
@@ -258,7 +261,7 @@ Add to your MCP client config (e.g., Claude Desktop, Claude Code):
 
 - **list_contacts** — List contacts with optional search, sorting (displayName, createdAt, modifiedAt), group filtering, and limit
 - **get_contact** — Get full contact details (emails, phones, addresses, URLs, social profiles, related names, dates)
-- **search_contacts** — Search contacts by name, organization, phone number, or email address
+- **search_contacts** — Search contacts by name, organization, phone number, or email address (results include phones and emails inline)
 - **list_groups** — List all contact groups with member counts
 - **list_group_members** — List contacts in a specific group
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/src/contacts/contacts.ts
+++ b/src/contacts/contacts.ts
@@ -6,6 +6,7 @@ import { ContactNotFoundError, GroupNotFoundError } from "./errors.ts";
 import type {
   Contact,
   ContactDetails,
+  ContactSummary,
   Group,
   ListContactsOptions,
   ListGroupsOptions,
@@ -35,7 +36,7 @@ export class Contacts {
     return contact;
   }
 
-  search(query: string, options?: SearchContactsOptions): Contact[] {
+  search(query: string, options?: SearchContactsOptions): ContactSummary[] {
     return this.reader.searchContacts(query, options);
   }
 

--- a/src/contacts/database/queries.ts
+++ b/src/contacts/database/queries.ts
@@ -61,6 +61,22 @@ export const LIST_PHONES = `
   ORDER BY ZISPRIMARY DESC, ZORDERINGINDEX ASC
 `;
 
+// Batched lookups for enriching search results: one query each for phones and
+// emails across many owners. The IN list is sized at call time (bun:sqlite
+// binds positionally). Ordering mirrors LIST_PHONES/LIST_EMAILS so per-owner
+// grouping keeps primary numbers/addresses first.
+export const PHONES_FOR_OWNERS = (n: number): string => `
+  SELECT ZOWNER as owner, ZFULLNUMBER as number, ZLABEL as label, ZISPRIMARY as isPrimary
+  FROM ZABCDPHONENUMBER WHERE ZOWNER IN (${Array(n).fill("?").join(",")})
+  ORDER BY ZISPRIMARY DESC, ZORDERINGINDEX ASC
+`;
+
+export const EMAILS_FOR_OWNERS = (n: number): string => `
+  SELECT ZOWNER as owner, ZADDRESS as address, ZLABEL as label, ZISPRIMARY as isPrimary
+  FROM ZABCDEMAILADDRESS WHERE ZOWNER IN (${Array(n).fill("?").join(",")})
+  ORDER BY ZISPRIMARY DESC, ZORDERINGINDEX ASC
+`;
+
 export const LIST_ADDRESSES = `
   SELECT ZSTREET as street, ZCITY as city, ZSTATE as state,
          ZZIPCODE as zipCode, ZCOUNTRYNAME as country, ZLABEL as label

--- a/src/contacts/database/reader.ts
+++ b/src/contacts/database/reader.ts
@@ -8,6 +8,7 @@ import type {
   ContactPhone,
   ContactRelatedName,
   ContactSocialProfile,
+  ContactSummary,
   ContactURL,
   Group,
   ListContactsOptions,
@@ -275,7 +276,61 @@ export class ContactReader {
     };
   }
 
-  searchContacts(query: string, options?: SearchContactsOptions): Contact[] {
+  // Enrich summary contacts with their phones and emails via two batched
+  // queries (not one-per-contact). Used by searchContacts so a lookup surfaces
+  // the contact methods people actually search for without a second round-trip.
+  private enrichWithContactMethods(contacts: Contact[]): ContactSummary[] {
+    if (contacts.length === 0) return [];
+
+    const ids = contacts.map((c) => c.id);
+
+    const phonesByOwner = new Map<number, ContactPhone[]>();
+    for (const r of this.db
+      .query(Q.PHONES_FOR_OWNERS(ids.length))
+      .all(...ids) as {
+      owner: number;
+      number: string;
+      label: string | null;
+      isPrimary: number;
+    }[]) {
+      const list = phonesByOwner.get(r.owner) ?? [];
+      list.push({
+        number: r.number,
+        label: this.cleanLabel(r.label),
+        isPrimary: r.isPrimary === 1,
+      });
+      phonesByOwner.set(r.owner, list);
+    }
+
+    const emailsByOwner = new Map<number, ContactEmail[]>();
+    for (const r of this.db
+      .query(Q.EMAILS_FOR_OWNERS(ids.length))
+      .all(...ids) as {
+      owner: number;
+      address: string;
+      label: string | null;
+      isPrimary: number;
+    }[]) {
+      const list = emailsByOwner.get(r.owner) ?? [];
+      list.push({
+        address: r.address,
+        label: this.cleanLabel(r.label),
+        isPrimary: r.isPrimary === 1,
+      });
+      emailsByOwner.set(r.owner, list);
+    }
+
+    return contacts.map((c) => ({
+      ...c,
+      phones: phonesByOwner.get(c.id) ?? [],
+      emails: emailsByOwner.get(c.id) ?? [],
+    }));
+  }
+
+  searchContacts(
+    query: string,
+    options?: SearchContactsOptions,
+  ): ContactSummary[] {
     const pattern = `%${query}%`;
     const rows = this.db
       .query(Q.SEARCH_CONTACTS)
@@ -295,7 +350,8 @@ export class ContactReader {
     }
 
     const limit = options?.limit ?? 50;
-    return results.slice(0, limit);
+    // Slice before enriching so we only fetch contact methods for returned rows.
+    return this.enrichWithContactMethods(results.slice(0, limit));
   }
 
   listGroups(options?: ListGroupsOptions): Group[] {

--- a/src/contacts/index.ts
+++ b/src/contacts/index.ts
@@ -12,6 +12,7 @@ export type {
   ContactRelatedName,
   ContactSocialProfile,
   ContactSortField,
+  ContactSummary,
   ContactURL,
   Group,
   GroupId,

--- a/src/contacts/mcp-tools.ts
+++ b/src/contacts/mcp-tools.ts
@@ -97,7 +97,7 @@ export function registerContactsTools(
     {
       title: "Search contacts",
       description:
-        "Search contacts by name, organization, phone number, or email address. Returns summary metadata for matches. Follow-up: use get_contact with a contactId for full details.",
+        "Search contacts by name, organization, phone number, or email address. Returns summary metadata plus phone numbers and email addresses for each match. Follow-up: use get_contact with a contactId for full details (addresses, social profiles, notes, etc.).",
       annotations: readOnlyAnnotations,
       inputSchema: {
         query: z

--- a/src/contacts/types.ts
+++ b/src/contacts/types.ts
@@ -59,6 +59,13 @@ export interface ContactDate {
   label: string | null;
 }
 
+// Search results carry the two contact methods people actually search for
+// (phones, emails) inline. The rest of ContactDetails still requires getContact.
+export interface ContactSummary extends Contact {
+  emails: ContactEmail[];
+  phones: ContactPhone[];
+}
+
 export interface ContactDetails extends Contact {
   emails: ContactEmail[];
   phones: ContactPhone[];

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -301,6 +301,26 @@ describe("search", () => {
     expect(results.length).toBeGreaterThan(0);
     expect(results.every((r) => r.firstName === "Jane")).toBe(true);
   });
+
+  test("includes phones and emails inline, primary first", () => {
+    const john = db.search("John").find((r) => r.firstName === "John");
+    expect(john).toBeDefined();
+
+    expect(john?.phones).toHaveLength(2);
+    expect(john?.phones[0]?.isPrimary).toBe(true);
+    expect(john?.phones[0]?.number).toBe("+1 (555) 123-4567");
+
+    expect(john?.emails).toHaveLength(2);
+    expect(john?.emails[0]?.isPrimary).toBe(true);
+    expect(john?.emails[0]?.address).toBe("john@acme.com");
+  });
+
+  test("returns empty arrays for a contact with no phones or emails", () => {
+    const bob = db.search("Bob").find((r) => r.firstName === "Bob");
+    expect(bob).toBeDefined();
+    expect(bob?.phones).toEqual([]);
+    expect(bob?.emails).toEqual([]);
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
`search_contacts` / `Contacts.search()` previously returned only summary metadata, so a phone number visible in Contacts.app never appeared in search output — it was only reachable via a follow-up `get_contact` call. Search now returns a new `ContactSummary` type that carries `phones` and `emails` inline (primary first), fetched via two batched per-owner queries run *after* the groupId filter and limit slice so only returned rows are enriched. The broad `list_contacts` / `list_group_members` browse paths stay lean (`Contact`, no contact methods), and full detail (addresses, social profiles, notes, etc.) still requires `get_contact`. Includes new tests asserting inline phones/emails (primary-first) and empty arrays for method-less contacts; docs updated and version bumped `0.13.1 → 0.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)