### PR TITLE
Fix multi-word contact search by matching each token across columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "macos-ts",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "TypeScript package for reading and searching Apple Notes, iMessages, Contacts, and more on macOS via direct SQLite access. Includes markdown conversion, attachment support, and offers a local MCP server!",
   "module": "src/index.ts",
   "main": "src/index.ts",

--- a/src/contacts/database/queries.ts
+++ b/src/contacts/database/queries.ts
@@ -25,19 +25,25 @@ export const GET_CONTACT = `
   WHERE r.Z_PK = ? AND r.Z_ENT = 22
 `;
 
-export const SEARCH_CONTACTS = `
-  SELECT DISTINCT ${CONTACT_COLUMNS}
-  FROM ZABCDRECORD r
-  LEFT JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
-  LEFT JOIN ZABCDEMAILADDRESS e ON e.ZOWNER = r.Z_PK
-  WHERE r.Z_ENT = 22
-    AND (
+// Each whitespace-separated query token must match at least one column; tokens
+// are AND-ed together so "Ben Sabrin" matches a contact with ZFIRSTNAME='Ben'
+// and ZLASTNAME='Sabrin' (no single column holds the whole phrase). Each clause
+// binds 5 `?` patterns positionally.
+const SEARCH_TOKEN_CLAUSE = `(
       r.ZFIRSTNAME LIKE ?
       OR r.ZLASTNAME LIKE ?
       OR r.ZORGANIZATION LIKE ?
       OR p.ZFULLNUMBER LIKE ?
       OR e.ZADDRESS LIKE ?
-    )
+    )`;
+
+export const SEARCH_CONTACTS = (tokenCount: number): string => `
+  SELECT DISTINCT ${CONTACT_COLUMNS}
+  FROM ZABCDRECORD r
+  LEFT JOIN ZABCDPHONENUMBER p ON p.ZOWNER = r.Z_PK
+  LEFT JOIN ZABCDEMAILADDRESS e ON e.ZOWNER = r.Z_PK
+  WHERE r.Z_ENT = 22
+    AND ${Array(tokenCount).fill(SEARCH_TOKEN_CLAUSE).join("\n    AND ")}
   ORDER BY r.ZSORTINGLASTNAME ASC, r.ZSORTINGFIRSTNAME ASC
 `;
 

--- a/src/contacts/database/reader.ts
+++ b/src/contacts/database/reader.ts
@@ -331,10 +331,16 @@ export class ContactReader {
     query: string,
     options?: SearchContactsOptions,
   ): ContactSummary[] {
-    const pattern = `%${query}%`;
+    const tokens = query.trim().split(/\s+/).filter(Boolean);
+    // Empty/whitespace query → preserve "match all" behavior with one empty token.
+    const effectiveTokens = tokens.length > 0 ? tokens : [""];
+    const params = effectiveTokens.flatMap((t) => {
+      const p = `%${t}%`;
+      return [p, p, p, p, p];
+    });
     const rows = this.db
-      .query(Q.SEARCH_CONTACTS)
-      .all(pattern, pattern, pattern, pattern, pattern) as ContactRow[];
+      .query(Q.SEARCH_CONTACTS(effectiveTokens.length))
+      .all(...params) as ContactRow[];
 
     let results = rows.map((r) => this.rowToContact(r));
 

--- a/tests/contacts.test.ts
+++ b/tests/contacts.test.ts
@@ -284,6 +284,35 @@ describe("search", () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
+  test("finds a contact by full name across columns", () => {
+    const results = db.search("John Doe");
+    expect(
+      results.some((r) => r.firstName === "John" && r.lastName === "Doe"),
+    ).toBe(true);
+  });
+
+  test("multi-word search is order-independent", () => {
+    const results = db.search("Doe John");
+    expect(
+      results.some((r) => r.firstName === "John" && r.lastName === "Doe"),
+    ).toBe(true);
+  });
+
+  test("multi-word search can span name and organization", () => {
+    const results = db.search("John Acme");
+    expect(
+      results.some((r) => r.firstName === "John" && r.lastName === "Doe"),
+    ).toBe(true);
+    // The organization-only "Acme Corporation" lacks a "John" token, so it
+    // should not match.
+    expect(results.every((r) => r.firstName === "John")).toBe(true);
+  });
+
+  test("returns empty when tokens match different contacts", () => {
+    const results = db.search("John Smith");
+    expect(results).toHaveLength(0);
+  });
+
   test("respects limit", () => {
     const results = db.search("a", { limit: 2 });
     expect(results.length).toBeLessThanOrEqual(2);


### PR DESCRIPTION
## Problem

`search_contacts {"query": "Ben Sabrin"}` returned no results while `{"query": "Sabrin"}` found the contact. The query matched the whole phrase as a single `%...%` pattern against each column independently, but first/last names are stored in separate columns, so no column ever contains the full phrase.

## Fix

The query is now split on whitespace into tokens that are AND-ed together, with each token matching any searchable column (first name, last name, organization, phone, email). Full names, reversed order (`"Sabrin Ben"`), and field-spanning queries (`"Ben Acme"`) all work now; an empty query still matches everything. Added four contacts-search test cases and bumped the patch version to 0.14.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)